### PR TITLE
fix: use prefix when suggesting namespaces in attribute value

### DIFF
--- a/packages/language-server/test/completion-items-spec.ts
+++ b/packages/language-server/test/completion-items-spec.ts
@@ -682,8 +682,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     ]);
   });
 
-  // Skipping until the bug is fixed (the attribute value is used for the suggestions instead of the prefix)
-  it.skip("will get completion values for UI5 xmlns value namespace when the cursor is in the middle of a name", () => {
+  it("will get completion values for UI5 xmlns value namespace when the cursor is in the middle of a name", () => {
     const xmlSnippet = `<mvc:View 
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="ux⇶a"`;
@@ -699,8 +698,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     ]);
   });
 
-  // Skipping until the bug is fixed (the attribute value is used for the suggestions instead of the prefix)
-  it.skip("will get completion values for UI5 xmlns value namespace FQN when the cursor is in the middle of a name", () => {
+  it("will get completion values for UI5 xmlns value namespace FQN when the cursor is in the middle of a name", () => {
     const xmlSnippet = `<mvc:View 
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns:uxap="sap.u⇶i"`;

--- a/packages/xml-views-completion/src/providers/attributeValue/namespace.ts
+++ b/packages/xml-views-completion/src/providers/attributeValue/namespace.ts
@@ -29,7 +29,7 @@ export function namespaceValueSuggestions(
 
   const ui5Model = opts.context;
 
-  const attributeValue = xmlAttribute.value ?? "";
+  const attributeValue = opts.prefix ?? "";
 
   let applicableNamespaces = values(ui5Model.namespaces);
 

--- a/packages/xml-views-completion/test/providers/attributeValue/namespace-spec.ts
+++ b/packages/xml-views-completion/test/providers/attributeValue/namespace-spec.ts
@@ -11,7 +11,6 @@ import { expectUI5Namespace } from "../attributeName/namespace-spec";
 import { expect } from "chai";
 import { partial } from "lodash";
 import { ui5NodeToFQN } from "@ui5-language-assistant/logic-utils";
-import { DEFAULT_NS } from "@xml-tools/ast";
 
 const expectNamespaceValuesSuggestions = partial(expectSuggestions, _ => {
   expectUI5Namespace(_.ui5Node);
@@ -222,20 +221,6 @@ describe("The ui5-editor-tools xml-views-completion", () => {
           prefix: ""
         });
         expect(suggestions).to.be.empty;
-      });
-
-      // test covers case when attribute value is null, that is impossible to reproduce
-      it("will suggest when attribute value is null", () => {
-        const xmlAttribute = createXMLAttribute("Control", "xmlns:tmpl", null, {
-          [DEFAULT_NS]: "sap.ui.core"
-        });
-        const suggestions = namespaceValueSuggestions({
-          attribute: xmlAttribute,
-          context: ui5SemanticModel,
-          element: xmlAttribute.parent,
-          prefix: "xmlns:tmpl"
-        });
-        expectNamespaceValuesSuggestions(suggestions, ["sap.ui.core.tmpl"]);
       });
     });
   });


### PR DESCRIPTION
Before the entire value was used even if the cursor was in the middle of the existing value.

Remove redundant test after bug fix.