### PR TITLE
refactor(language-server): move classes code completion tests to other file

### DIFF
--- a/packages/language-server/test/completion-items-utils.ts
+++ b/packages/language-server/test/completion-items-utils.ts
@@ -1,0 +1,234 @@
+import { forEach } from "lodash";
+import { expect } from "chai";
+import {
+  TextDocument,
+  TextDocumentPositionParams,
+  Position,
+  TextDocumentIdentifier,
+  CompletionItem,
+  TextEdit,
+  Range
+} from "vscode-languageserver";
+import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
+import { expectExists } from "@ui5-language-assistant/test-utils";
+import { getCompletionItems } from "../src/completion-items";
+
+/** Return the first part of a tag name suggestion insert text */
+export function getTagName(textEdit: TextEdit | undefined): string | undefined {
+  if (textEdit === undefined) {
+    return undefined;
+  }
+  const result = /^([^> ]*)/.exec(textEdit.newText);
+  return result?.[1];
+}
+
+/** Use ⇶ to mark the cursor position */
+export function getSuggestions(
+  xmlSnippet: string,
+  ui5SemanticModel: UI5SemanticModel
+): CompletionItem[] {
+  const { document, position } = getXmlSnippetDocument(xmlSnippet);
+  const uri: TextDocumentIdentifier = { uri: "uri" };
+  const textDocPositionParams: TextDocumentPositionParams = {
+    textDocument: uri,
+    position: position
+  };
+
+  const suggestions = getCompletionItems(
+    ui5SemanticModel,
+    textDocPositionParams,
+    document
+  );
+  // Check that all returned suggestions will be displayed to the user
+  assertSuggestionsAreValid(suggestions, xmlSnippet);
+  return suggestions;
+}
+
+function createTextDocument(languageId: string, content: string): TextDocument {
+  return TextDocument.create("uri", languageId, 0, content);
+}
+
+function getXmlSnippetDocument(
+  xmlSnippet: string
+): { document: TextDocument; position: Position } {
+  const xmlSnippetWithoutRanges = xmlSnippet
+    .replace(/⭲/g, "")
+    .replace(/⭰/g, "");
+  const xmlText = xmlSnippetWithoutRanges.replace("⇶", "");
+  const offset = xmlSnippetWithoutRanges.indexOf("⇶");
+  const document: TextDocument = createTextDocument("xml", xmlText);
+  const position: Position = document.positionAt(offset);
+  return { document, position };
+}
+
+/** Use ⭲ to mark range start and ⭰ to mark range end */
+export function getRanges(xmlSnippet: string): Range[] {
+  const RANGE_START_CHAR = "⭲";
+  const RANGE_END_CHAR = "⭰";
+
+  const { document } = getXmlSnippetDocument(xmlSnippet);
+  const ranges: Range[] = [];
+  let xmlTextWithRanges = xmlSnippet.replace("⇶", "");
+  while (xmlTextWithRanges.indexOf(RANGE_START_CHAR) !== -1) {
+    const rangeStartIndex = xmlTextWithRanges.indexOf(RANGE_START_CHAR);
+    xmlTextWithRanges = xmlTextWithRanges.replace(RANGE_START_CHAR, "");
+    const rangeEndIndex = xmlTextWithRanges.indexOf(RANGE_END_CHAR);
+    if (rangeEndIndex === -1) {
+      break;
+    }
+    xmlTextWithRanges = xmlTextWithRanges.replace(RANGE_END_CHAR, "");
+    ranges.push({
+      start: document.positionAt(rangeStartIndex),
+      end: document.positionAt(rangeEndIndex)
+    });
+  }
+  return ranges;
+}
+
+export function getTextInRange(
+  xmlSnippet: string,
+  range: Range | undefined
+): string {
+  const { document } = getXmlSnippetDocument(xmlSnippet);
+  return document.getText(range);
+}
+
+function rangeToString(range: Range): string {
+  return `${range.start.line}:${range.start.character}-${range.end.line}:${range.end.character}`;
+}
+
+/** Check the suggestions will be displayed to the user according to the range and filter text */
+function assertSuggestionsAreValid(
+  suggestions: CompletionItem[],
+  xmlSnippet: string
+): void {
+  const { document, position } = getXmlSnippetDocument(xmlSnippet);
+  forEach(suggestions, suggestion => {
+    expectExists(suggestion.textEdit, "suggestion contains a textEdit");
+    assertRangeContains(suggestion.textEdit.range, position, suggestion.label);
+    assertRangesDoNotOverlap(
+      suggestion.label,
+      suggestion.textEdit,
+      suggestion.additionalTextEdits || []
+    );
+    // The filter text is checked until the position in the document
+    // (for example, we can replace "Ab⇶cd" with "Abzzz" even though "c" and "d" aren't in "Abzzz")
+    const checkedRange = {
+      start: suggestion.textEdit?.range.start,
+      end: position
+    };
+    assertFilterMatches(
+      suggestion.filterText ?? suggestion.label,
+      document.getText(checkedRange),
+      suggestion.label
+    );
+  });
+}
+
+function assertRangeContains(
+  range: Range,
+  position: Position,
+  description: string
+): void {
+  // The range must be in the same line as the position
+  expect(range.start.line, `${description}: range start line`).to.equal(
+    position.line
+  );
+  expect(range.end.line, `${description}: range end line`).to.equal(
+    position.line
+  );
+  expect(
+    range.start.character,
+    `${description}: range start character`
+  ).to.be.at.most(position.character);
+  expect(
+    range.end.character,
+    `${description}: range end character`
+  ).to.be.at.least(position.character);
+}
+
+function assertRangesDoNotOverlap(
+  description: string,
+  textEdit: TextEdit,
+  additionalTextEdits: TextEdit[]
+): void {
+  // First, sort the text edits by range start and end
+  const allEdits = [textEdit].concat(additionalTextEdits);
+  allEdits.sort((first, second) => {
+    if (first.range.start.line < second.range.start.line) {
+      return -1;
+    }
+    if (
+      first.range.start.line === second.range.start.line &&
+      first.range.start.character < second.range.start.character
+    ) {
+      return -1;
+    }
+    if (first.range.end.line < second.range.end.line) {
+      return -1;
+    }
+    if (
+      first.range.end.line === second.range.end.line &&
+      first.range.end.character < second.range.end.character
+    ) {
+      return -1;
+    }
+    if (
+      first.range.start.line === second.range.start.line &&
+      first.range.start.character === second.range.start.character &&
+      first.range.end.line === second.range.end.line &&
+      first.range.end.character === second.range.end.character
+    ) {
+      return 0;
+    }
+    return 1;
+  });
+
+  // Check for overlap between every 2 consecutive text edits
+  for (let i = 0; i < allEdits.length - 1; ++i) {
+    const first = allEdits[i];
+    const second = allEdits[i + 1];
+    // Since we sorted them by range start and end, they would overlap if and only if
+    // the second range start position is less than or equal to the first range end position.
+    const overlapping =
+      second.range.start.line < first.range.end.line ||
+      (second.range.start.line === first.range.end.line &&
+        second.range.start.character <= first.range.end.character);
+    expect(
+      overlapping,
+      `${description}: found overlapping text edits: "${
+        first.newText
+      }" at ${rangeToString(first.range)} and "${
+        second.newText
+      }" at ${rangeToString(second.range)}`
+    ).to.be.false;
+  }
+}
+
+function assertFilterMatches(
+  filterText: string,
+  text: string,
+  description: string
+): void {
+  // This is a simple matcher - all characters in text are found in filterText in the same order.
+  // For example, if the user requests code assist for "But" the filter text must contains "B", "u" and "t"
+  // in this order (the filter text might be "sap.m.Button").
+  // Actual filtering can be more complex, but if this filter doesn't pass the suggestion will likely not be
+  // displayed to the user.
+  let contains = true;
+  let indexInFilterText = 0;
+  forEach(text, character => {
+    if (contains) {
+      const characterIndex = filterText.indexOf(character, indexInFilterText);
+      if (characterIndex < 0) {
+        contains = false;
+      } else {
+        indexInFilterText = characterIndex + 1;
+      }
+    }
+  });
+  expect(
+    contains,
+    `${description}: ${filterText} does not contain all characters from ${text} in order`
+  ).to.be.true;
+}

--- a/packages/language-server/test/copmletion-items-classes-spec.ts
+++ b/packages/language-server/test/copmletion-items-classes-spec.ts
@@ -1,0 +1,403 @@
+import { expect } from "chai";
+import { map, uniq, forEach } from "lodash";
+import { CompletionItemKind, TextEdit } from "vscode-languageserver";
+import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
+import {
+  generateModel,
+  GEN_MODEL_TIMEOUT
+} from "@ui5-language-assistant/test-utils";
+import {
+  getSuggestions,
+  getRanges,
+  getTextInRange,
+  getTagName
+} from "./completion-items-utils";
+
+describe("the UI5 language assistant Code Completion Services - classes", () => {
+  let ui5SemanticModel: UI5SemanticModel;
+  before(async function() {
+    this.timeout(GEN_MODEL_TIMEOUT);
+    //TODO: use 1.71.x
+    ui5SemanticModel = await generateModel({ version: "1.74.0" });
+  });
+
+  /** Return the attributes from a tag name suggestion insert text  */
+  function getAttributes(textEdit: TextEdit | undefined): string[] {
+    if (textEdit === undefined) {
+      return [];
+    }
+    const result = /^[^ ]+ ([^>]+)/.exec(textEdit.newText);
+    return result?.[1].split(" ") ?? [];
+  }
+
+  it("will get completion values for UI5 class", () => {
+    const xmlSnippet = `<GridLi⇶`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      { label: "GridList", tagName: "f:GridList", replacedText: "GridLi" },
+      {
+        label: "GridListItem",
+        tagName: "f:GridListItem",
+        replacedText: "GridLi"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will get completion values for UI5 class by fully qualified name", () => {
+    const xmlSnippet = `<sap.m.Busy⇶`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      firstAttribute: getAttributes(suggestion.textEdit)[0],
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "BusyDialog",
+        tagName: "m:BusyDialog",
+        firstAttribute: `xmlns:m="sap.m"`,
+        replacedText: "sap.m.Busy"
+      },
+      {
+        label: "BusyIndicator",
+        tagName: "m:BusyIndicator",
+        firstAttribute: `xmlns:m="sap.m"`,
+        replacedText: "sap.m.Busy"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will insert class namespace with a new name when another namespace with the short name is defined", () => {
+    const xmlSnippet = `<sap.m.BusyI⇶ xmlns:m="sap.ui.core.mvc"`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      firstAttribute: getAttributes(suggestion.textEdit)[0],
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "BusyIndicator",
+        tagName: "m2:BusyIndicator",
+        firstAttribute: `xmlns:m2="sap.m"`,
+        replacedText: "sap.m.BusyI"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will get completion values for UI5 class when the cursor is in the middle of a name", () => {
+    const xmlSnippet = `<Busy⇶Dialo`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      firstAttribute: getAttributes(suggestion.textEdit)[0],
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "BusyDialog",
+        tagName: "m:BusyDialog",
+        firstAttribute: `xmlns:m="sap.m"`,
+        replacedText: "BusyDialo"
+      },
+      {
+        label: "BusyIndicator",
+        tagName: "m:BusyIndicator",
+        firstAttribute: `xmlns:m="sap.m"`,
+        replacedText: "BusyDialo"
+      },
+      {
+        label: "LocalBusyIndicator",
+        tagName: "core:LocalBusyIndicator",
+        firstAttribute: `xmlns:core="sap.ui.core"`,
+        replacedText: "BusyDialo"
+      },
+      {
+        label: "InboxBusyIndicator",
+        tagName: "composite:InboxBusyIndicator",
+        firstAttribute: `xmlns:composite="sap.uiext.inbox.composite"`,
+        replacedText: "BusyDialo"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will get completion values for UI5 class FQN when the cursor is in the middle of a name", () => {
+    const xmlSnippet = `<sap.m.Busy⇶Dialo`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      firstAttribute: getAttributes(suggestion.textEdit)[0],
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "BusyDialog",
+        tagName: "m:BusyDialog",
+        firstAttribute: `xmlns:m="sap.m"`,
+        replacedText: "sap.m.BusyDialo"
+      },
+      {
+        label: "BusyIndicator",
+        tagName: "m:BusyIndicator",
+        firstAttribute: `xmlns:m="sap.m"`,
+        replacedText: "sap.m.BusyDialo"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will get completion values for UI5 class with namespace when the cursor is in the middle of a name", () => {
+    const xmlSnippet = `<m:Busy⇶Dialo xmlns:m="sap.m"`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      attributes: getAttributes(suggestion.textEdit),
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "BusyDialog",
+        tagName: "m:BusyDialog",
+        attributes: [],
+        replacedText: "m:BusyDialo"
+      },
+      {
+        label: "BusyIndicator",
+        tagName: "m:BusyIndicator",
+        attributes: [],
+        replacedText: "m:BusyDialo"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will get completion values for UI5 class from all namespaces when default namespace exists", () => {
+    const xmlSnippet = `<RadioButtonGrou⇶ xmlns="sap.m" xmlns:commons="sap.ui.commons"`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "RadioButtonGroup",
+        tagName: "RadioButtonGroup",
+        replacedText: "RadioButtonGrou"
+      },
+      {
+        label: "RadioButtonGroup",
+        tagName: "commons:RadioButtonGroup",
+        replacedText: "RadioButtonGrou"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will get completion values for UI5 class from a specific namespace", () => {
+    const xmlSnippet = `<f:Ca⇶ xmlns:f="sap.f"`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      attributes: getAttributes(suggestion.textEdit),
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      { label: "Card", tagName: "f:Card", attributes: [], replacedText: "f:Ca" }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will get completion values for UI5 class from a specific namespace when name is not the parent name", () => {
+    const xmlSnippet = `<g:Ca⇶ xmlns:g="sap.f"`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      attributes: getAttributes(suggestion.textEdit),
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      { label: "Card", tagName: "g:Card", attributes: [], replacedText: "g:Ca" }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will not insert the namespace when selecting completion for class in inner tag and namespace is already defined", () => {
+    const xmlSnippet = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:m="sap.m">
+        <content>
+          <sap.m.MenuButto⇶n
+        </content>
+      </m:View>`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      additionalTextEdits: suggestion.additionalTextEdits,
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "MenuButton",
+        tagName: "m:MenuButton",
+        additionalTextEdits: [],
+        replacedText: "sap.m.MenuButton"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will insert the namespace when selecting completion for class in inner tag and namespace is not defined", () => {
+    const xmlSnippet = `<m:View⭲⭰ xmlns:m="sap.ui.core.mvc">
+        <content>
+          <MenuButton⇶
+        </content>
+      </m:View>`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      additionalTextEdits: suggestion.additionalTextEdits,
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    const suggestionKinds = uniq(
+      map(suggestions, suggestion => suggestion.kind)
+    );
+
+    const ranges = getRanges(xmlSnippet);
+    expect(ranges, "additional text edits ranges").to.have.lengthOf(1);
+
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "MenuButton",
+        tagName: "m2:MenuButton",
+        additionalTextEdits: [
+          {
+            range: ranges[0],
+            newText: ` xmlns:m2="sap.m"`
+          }
+        ],
+        replacedText: "MenuButton"
+      },
+      {
+        label: "MenuButton",
+        tagName: "commons:MenuButton",
+        additionalTextEdits: [
+          {
+            range: ranges[0],
+            newText: ` xmlns:commons="sap.ui.commons"`
+          }
+        ],
+        replacedText: "MenuButton"
+      }
+    ]);
+
+    expect(suggestionKinds).to.deep.equal([CompletionItemKind.Class]);
+  });
+
+  it("will not get completion values for unknown class", () => {
+    const xmlSnippet = `<Unknown⇶`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    expect(suggestions).to.be.empty;
+  });
+
+  it("will return valid class suggestions for empty tag", () => {
+    const xmlSnippet = `<⇶`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    expect(suggestions).to.not.be.empty;
+    forEach(suggestions, suggestion => {
+      // We're not replacing any text, just adding
+      expect(getTextInRange(xmlSnippet, suggestion.textEdit?.range)).to.equal(
+        ""
+      );
+    });
+  });
+
+  it("will get completion values for UI5 experimental class", () => {
+    const xmlSnippet = `<mvc:View 
+                          xmlns:mvc="sap.ui.core.mvc" 
+                          xmlns="sap.m">
+                          <content> <ContentS⇶`;
+    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestionsDetails = map(suggestions, suggestion => ({
+      label: suggestion.label,
+      tagName: getTagName(suggestion.textEdit),
+      replacedText: getTextInRange(xmlSnippet, suggestion.textEdit?.range)
+    }));
+    expect(suggestionsDetails).to.deep.equalInAnyOrder([
+      {
+        label: "ContentSwitcher",
+        tagName: "unified:ContentSwitcher",
+        replacedText: "ContentS"
+      }
+    ]);
+    forEach(suggestions, suggestion => {
+      expect(suggestion.detail).to.contain("experimental");
+    });
+  });
+});


### PR DESCRIPTION
The tests did not change except for one test that uses a new utility function to get the range for the `additionalTextEdits`:
`"will insert the namespace when selecting completion for class in inner tag and namespace is not defined"`

Utility functions moved to their own file.
Changes to utility functions:
* Added assertion that text edits don't overlap (`assertRangesDoNotOverlap`)
* Added model parameter to `getSuggestions` (since it's no longer in a closure)
* Added handling of `additionalTextEdits` ranges in `getSuggestions` 
* Added function `getRanges`
* Extracted function `getXmlSnippetDocument` from `getSuggestions`