### PR TITLE
refactor(xml-views-validation): remove description in deprecation issue

### DIFF
--- a/packages/language-server/src/documentation.ts
+++ b/packages/language-server/src/documentation.ts
@@ -79,7 +79,7 @@ export function getNodeDocumentation(
   return markdownContent;
 }
 
-function convertDescriptionToMarkup(
+export function convertDescriptionToMarkup(
   jsdocDescription: string,
   model: UI5SemanticModel
 ): MarkupContent {

--- a/packages/language-server/test/snapshots/xml-view-diagnostics/use-of-deprecated-class/output-lsp-response.json
+++ b/packages/language-server/test/snapshots/xml-view-diagnostics/use-of-deprecated-class/output-lsp-response.json
@@ -6,7 +6,7 @@
     },
     "severity": 2,
     "source": "UI5 Language Assistant",
-    "message": "UI5 Class sap.ui.commons.Button is deprecated since: 1.38.\n\treplaced by {@link sap.m.Button}.",
+    "message": "UI5 Class sap.ui.commons.Button is deprecated since version: 1.38.",
     "tags": [2]
   }
 ]

--- a/packages/xml-views-validation/src/utils/deprecated-message-builder.ts
+++ b/packages/xml-views-validation/src/utils/deprecated-message-builder.ts
@@ -13,11 +13,10 @@ export function buildDeprecatedIssueMessage({
 }): string {
   const msgPrefix = `UI5 ${ui5Kind} ${fqn} is deprecated`;
   const sinceOptionalPart = deprecatedInfo.since
-    ? ` since: ${deprecatedInfo.since}`
-    : "";
-  const detailsOptionalPart = deprecatedInfo.text
-    ? `\n\t${deprecatedInfo.text}.`
+    ? ` since version: ${deprecatedInfo.since}`
     : "";
 
-  return `${msgPrefix}${sinceOptionalPart}.${detailsOptionalPart}`;
+  // we are ignoring the deprecated description because there is no way to render
+  // a link or complex messages nicely in the problems views (unlike in completions use case).
+  return `${msgPrefix}${sinceOptionalPart}.`;
 }

--- a/packages/xml-views-validation/test/utils/deprecated-message-builder-spec.ts
+++ b/packages/xml-views-validation/test/utils/deprecated-message-builder-spec.ts
@@ -3,22 +3,6 @@ import { buildUI5DeprecatedInfo } from "@ui5-language-assistant/test-utils/";
 import { buildDeprecatedIssueMessage } from "../../src/utils/deprecated-message-builder";
 
 describe("the deprecated message builder", () => {
-  it("can build a full message with 'since' and 'details'", () => {
-    const deprecatedInfo = buildUI5DeprecatedInfo({
-      text: "use osem.Bamba instead",
-      since: "version 6.6.6",
-    });
-
-    const actualMessage = buildDeprecatedIssueMessage({
-      ui5Kind: "Class",
-      fqn: "osem.Bisli",
-      deprecatedInfo,
-    });
-    expect(actualMessage).to.eql(
-      "UI5 Class osem.Bisli is deprecated since: version 6.6.6.\n\tuse osem.Bamba instead."
-    );
-  });
-
   it("can build a message with only the prefix", () => {
     const deprecatedInfo = buildUI5DeprecatedInfo({});
 
@@ -30,9 +14,9 @@ describe("the deprecated message builder", () => {
     expect(actualMessage).to.eql("UI5 Class osem.Bisli is deprecated.");
   });
 
-  it("can build a message with only the prefix and the `since` info", () => {
+  it("can build a message with both the prefix and the `since` info", () => {
     const deprecatedInfo = buildUI5DeprecatedInfo({
-      since: "version 6.6.6",
+      since: "6.6.6",
     });
 
     const actualMessage = buildDeprecatedIssueMessage({
@@ -41,22 +25,7 @@ describe("the deprecated message builder", () => {
       deprecatedInfo,
     });
     expect(actualMessage).to.eql(
-      "UI5 Class osem.Bisli is deprecated since: version 6.6.6."
-    );
-  });
-
-  it("can build a message with only the prefix and the `details` info", () => {
-    const deprecatedInfo = buildUI5DeprecatedInfo({
-      text: "use osem.Bamba instead",
-    });
-
-    const actualMessage = buildDeprecatedIssueMessage({
-      ui5Kind: "Class",
-      fqn: "osem.Bisli",
-      deprecatedInfo,
-    });
-    expect(actualMessage).to.eql(
-      "UI5 Class osem.Bisli is deprecated.\n\tuse osem.Bamba instead."
+      "UI5 Class osem.Bisli is deprecated since version: 6.6.6."
     );
   });
 });

--- a/packages/xml-views-validation/test/validators/element/use-of-deprecated-class-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/use-of-deprecated-class-spec.ts
@@ -40,7 +40,7 @@ describe("the use of deprecated class validation", () => {
             {
               kind: "UseOfDeprecatedClass",
               message:
-                "UI5 Class sap.ui.commons.Button is deprecated since: 1.38.\n\treplaced by {@link sap.m.Button}.",
+                "UI5 Class sap.ui.commons.Button is deprecated since version: 1.38.",
               severity: "warn",
               offsetRange: computeExpectedRange(xmlSnippet),
             },
@@ -72,7 +72,7 @@ describe("the use of deprecated class validation", () => {
             {
               kind: "UseOfDeprecatedClass",
               message:
-                "UI5 Class sap.ui.commons.Button is deprecated since: 1.38.\n\treplaced by {@link sap.m.Button}.",
+                "UI5 Class sap.ui.commons.Button is deprecated since version: 1.38.",
               severity: "warn",
               offsetRange: computeExpectedRange(xmlSnippet),
             },
@@ -105,7 +105,7 @@ describe("the use of deprecated class validation", () => {
             {
               kind: "UseOfDeprecatedClass",
               message:
-                "UI5 Class sap.ui.commons.Button is deprecated since: 1.38.\n\treplaced by {@link sap.m.Button}.",
+                "UI5 Class sap.ui.commons.Button is deprecated since version: 1.38.",
               severity: "warn",
               offsetRange: computeExpectedRange(xmlSnippet),
             },


### PR DESCRIPTION
The description is often links which cannot be redered as there is no support for markdown, or
complex text which would become unreadable spam, again due to no "smart" rendering.