### PR TITLE
fix: check unknown namespaces according to the defined namespaces

### DIFF
--- a/packages/xml-views-validation/src/validators/attributes/unknown-xmlns-namespace.ts
+++ b/packages/xml-views-validation/src/validators/attributes/unknown-xmlns-namespace.ts
@@ -25,11 +25,12 @@ export function validateUnknownXmlnsNamespace(
   // Only check namespaces from libraries.
   // There are valid namespaces like some that start with "http" that should not return an error.
   // Additionally, customers can develop in custom namespaces, even those that start with "sap", and we don't want to give false positives.
-  // But sap library namespaces can be considered reserved.
+  // But sap library namespaces (i.e. first-level namespaces under "sap") can be considered reserved.
+  /* istanbul ignore next - defensive programming - "sap" namespace should always exist in production scenarios */
+  const reservedNamespaceRoots = model.namespaces["sap"]?.namespaces;
   if (
-    find(
-      model.includedLibraries,
-      (_) => attributeValue === _ || attributeValue.startsWith(_ + ".")
+    find(reservedNamespaceRoots, (_, fqn) =>
+      attributeValue.startsWith(fqn + ".")
     ) === undefined
   ) {
     return [];


### PR DESCRIPTION
Instead of checking the library names, check all namespaces under "sap".