### PR TITLE
fix: remove message for "sap.ui.vk.BaseNodeProxy" on library startup

### DIFF
--- a/packages/semantic-model/src/fix-api-json.ts
+++ b/packages/semantic-model/src/fix-api-json.ts
@@ -1,7 +1,10 @@
-import { forEach, find, get } from "lodash";
+import { forEach, find, get, remove } from "lodash";
 
 type LibraryFix = (libraryName: string, content: unknown) => void;
-const libraryFixes: LibraryFix[] = [addViewDefaultAggregation];
+const libraryFixes: LibraryFix[] = [
+  addViewDefaultAggregation,
+  fixSelfImplementingClass,
+];
 
 export function fixLibrary(libraryName: string, fileContent: unknown): void {
   forEach(libraryFixes, (fix) => {
@@ -24,4 +27,17 @@ export function addViewDefaultAggregation(
       metadata.defaultAggregation = "content";
     }
   }
+}
+
+export function fixSelfImplementingClass(
+  libraryName: string,
+  content: unknown
+): void {
+  // This fixes class "sap.ui.vk.BaseNodeProxy" which has itself in its "implements" array
+  forEach(get(content, "symbols"), (symbol) => {
+    if (get(symbol, "kind") === "class") {
+      const symbolName = get(symbol, "name");
+      remove(symbol.implements, (name) => name === symbolName);
+    }
+  });
 }

--- a/test-packages/test-utils/src/utils/semantic-model-provider.ts
+++ b/test-packages/test-utils/src/utils/semantic-model-provider.ts
@@ -238,18 +238,10 @@ export async function generateModel({
 
 // Fix functions for model issues unfixable by schema changes
 type LibraryFix = (content: Json) => void;
-const fixBaseNodeProxyImplements = (content: Json): void => {
-  const symbol = find(
-    get(content, "symbols"),
-    (symbol) => symbol.name === "sap.ui.vk.BaseNodeProxy"
-  );
-  remove(symbol.implements, (name) => name === "sap.ui.vk.BaseNodeProxy");
-};
 
 // Library version -> library name -> fix function
 const libraryFixes: Record<TestModelVersion, Record<string, LibraryFix[]>> = {
   "1.60.14": {
-    "sap.ui.vk": [fixBaseNodeProxyImplements],
     "sap.ushell": [
       (content: Json): void => {
         const symbol = find(
@@ -264,11 +256,8 @@ const libraryFixes: Record<TestModelVersion, Record<string, LibraryFix[]>> = {
       },
     ],
   },
-  "1.71.14": {
-    "sap.ui.vk": [fixBaseNodeProxyImplements],
-  },
+  "1.71.14": {},
   "1.74.0": {
-    "sap.ui.vk": [fixBaseNodeProxyImplements],
     "sap.ui.generic.app": [
       (content: Json): void => {
         // Removing from this library. There is another symbol with the same name in library "sap.fe".


### PR DESCRIPTION
Remove it from its "implements" array when building the model.
Note: I didn't add tests since the strict model building tests already check this (I removed the same fix from the test code).