### PR TITLE
fix: use shorter description without jsdoc tags in deprecation warning

### DIFF
--- a/packages/language-server/src/documentation.ts
+++ b/packages/language-server/src/documentation.ts
@@ -12,6 +12,9 @@ import {
   ui5NodeToFQN,
   isRootSymbol,
   typeToString,
+  getDeprecationMessage,
+  convertJSDocToMarkdown,
+  getLink,
 } from "@ui5-language-assistant/logic-utils";
 import { GENERATED_LIBRARY } from "@ui5-language-assistant/semantic-model";
 
@@ -34,15 +37,10 @@ export function getNodeDocumentation(
     if (contents !== "") {
       contents += NL;
     }
-    contents += "Deprecated";
-    /* istanbul ignore next */
-    contents += node.deprecatedInfo.since
-      ? ` since version ${node.deprecatedInfo.since}`
-      : EMPTY_STRING;
-    contents += ".";
-    contents += node.deprecatedInfo.text
-      ? ` ${node.deprecatedInfo.text}`
-      : EMPTY_STRING;
+    contents += getDeprecationMessage({
+      since: node.deprecatedInfo.since,
+      text: node.deprecatedInfo.text,
+    });
     contents += NL;
   }
 
@@ -70,7 +68,10 @@ export function getNodeDocumentation(
 
   contents += node.description ? node.description + NL : EMPTY_STRING;
 
-  const markdownContent = convertDescriptionToMarkup(contents, model);
+  const markdownContent: MarkupContent = {
+    kind: "markdown",
+    value: convertJSDocToMarkdown(contents, model),
+  };
 
   const symbolForDocumentation = getRootSymbolParent(node);
   /* istanbul ignore else */
@@ -83,80 +84,6 @@ export function getNodeDocumentation(
   }
 
   return markdownContent;
-}
-
-function convertDescriptionToMarkup(
-  jsdocDescription: string,
-  model: UI5SemanticModel
-): MarkupContent {
-  let contents = jsdocDescription;
-
-  // Italics
-  contents = contents.replace(/<i>(.+?)<\/i>/g, "*$1*");
-
-  // Bold
-  contents = contents.replace(/<b>(.+?)<\/b>/g, "**$1**");
-  contents = contents.replace(/<strong>(.+?)<\/strong>/g, "**$1**");
-
-  // Emphasis
-  contents = contents.replace(/<em>(.+?)<\/em>/g, "***$1***");
-
-  // Headers
-  contents = contents.replace(/<h1>(.+?)<\/h1>/g, "\n# $1\n\n");
-  contents = contents.replace(/<h2>(.+?)<\/h2>/g, "\n## $1\n\n");
-  contents = contents.replace(/<h3>(.+?)<\/h3>/g, "\n### $1\n\n");
-  contents = contents.replace(/<h4>(.+?)<\/h4>/g, "\n#### $1\n\n");
-
-  // Lists
-  contents = contents.replace(/<li>(.+?)<\/li>/g, "\n* $1");
-  contents = contents.replace(/<ul>/g, "");
-  contents = contents.replace(/<\/ul>/g, "\n\n");
-  // TODO should we handled ordered lists (ol)?
-
-  // Code value
-  contents = contents.replace(/<code>(.+?)<\/code>/g, "`$1`");
-
-  // Code block
-  contents = contents.replace(
-    /<pre>([^]+?)<\/pre>/g,
-    "\n```javascript\n$1```\n"
-  );
-
-  // Line break
-  contents = contents.replace(/<br\/>/g, "\n");
-  contents = contents.replace(/<br>/g, "\n");
-  contents = contents.replace(/<\/br>/g, "\n");
-
-  // "&lt;View" --> "<View"
-  contents = unescape(contents);
-
-  // Links
-  // Assuming links are of the form: {@link <type>[ <text>]}
-  // Where the type doesn't contain whitespace, and neither the type nor text contain the "}" character
-  contents = contents.replace(
-    /{@link (([^\s}]+)\s)?([^}]+)}/g,
-    (all, _, type, text) => {
-      /* istanbul ignore next */
-      return `[${text}](${getLink(model, type ?? text)})`;
-    }
-  );
-
-  return {
-    kind: "markdown",
-    value: contents,
-  };
-}
-
-function getLink(model: UI5SemanticModel, link: string): string {
-  if (link.startsWith("http:") || link.startsWith("https:")) {
-    return link;
-  }
-  /* istanbul ignore else */
-  if (model.version) {
-    return `https://sapui5.hana.ondemand.com/${model.version}/#/api/${link}`;
-  }
-  /* istanbul ignore next */
-  return `https://sapui5.hana.ondemand.com/#/api/${link}`;
 }
 
 export function getNodeDetail(node: BaseUI5Node): string {

--- a/packages/language-server/test/snapshots/xml-view-diagnostics/use-of-deprecated-class/output-lsp-response.json
+++ b/packages/language-server/test/snapshots/xml-view-diagnostics/use-of-deprecated-class/output-lsp-response.json
@@ -6,7 +6,7 @@
     },
     "severity": 2,
     "source": "UI5 Language Assistant",
-    "message": "UI5 Class sap.ui.commons.Button is deprecated since: 1.38.\n\treplaced by {@link sap.m.Button}.",
+    "message": "The sap.ui.commons.Button class is deprecated since version 1.38. replaced by sap.m.Button",
     "tags": [2]
   }
 ]

--- a/packages/logic-utils/api.d.ts
+++ b/packages/logic-utils/api.d.ts
@@ -136,7 +136,7 @@ export function getUI5NodeFromXMLElementNamespace(
  * @param opts.title - The opening sentance for the deprecation message. It should not contain a dot. "Deprecated" by default.
  */
 export function getDeprecationMessage(opts: {
-  title?: string | undefined;
+  title?: string;
   since: string | undefined;
   text: string | undefined;
 }): string;

--- a/packages/logic-utils/api.d.ts
+++ b/packages/logic-utils/api.d.ts
@@ -9,6 +9,7 @@ import {
   UI5Association,
   UI5SemanticModel,
   UI5Type,
+  UI5DeprecatedInfo,
 } from "@ui5-language-assistant/semantic-model-types";
 
 /**
@@ -128,3 +129,48 @@ export function getUI5NodeFromXMLElementNamespace(
   isDefault: boolean;
   isXmlnsDefined: boolean;
 };
+
+/**
+ * Get the deprecated message. The returned string contains jsdoc tags.
+ *
+ * @param opts.title - The opening sentance for the deprecation message. It should not contain a dot. "Deprecated" by default.
+ */
+export function getDeprecationMessage(opts: {
+  title?: string | undefined;
+  since: string | undefined;
+  text: string | undefined;
+}): string;
+
+/**
+ * Get a snippet (first line) of the deprecated documentation without jsdoc tags.
+ *
+ * @param title - The opening sentance for the deprecation message. It should not contain a dot. "Deprecated" by default.
+ * @param deprecatedInfo
+ * @param model
+ */
+export function getDeprecationPlainTextSnippet(
+  title: string | undefined,
+  deprecatedInfo: UI5DeprecatedInfo,
+  model: UI5SemanticModel
+): string;
+
+/**
+ * Convert jsdoc description to markdown format string
+ * @param jsdocDescription
+ * @param model
+ */
+export function convertJSDocToMarkdown(
+  jsdocDescription: string,
+  model: UI5SemanticModel
+): string;
+
+/**
+ * Get a link according to the link text.
+ * Supported links:
+ * - http/https links - returned as-is
+ * - Other strings are considered to be UI5 FQNs. A link to the relevant SDK page is returned.
+ *
+ * @param model
+ * @param link
+ */
+export function getLink(model: UI5SemanticModel, link: string): string;

--- a/packages/logic-utils/api.d.ts
+++ b/packages/logic-utils/api.d.ts
@@ -133,7 +133,7 @@ export function getUI5NodeFromXMLElementNamespace(
 /**
  * Get the deprecated message. The returned string contains jsdoc tags.
  *
- * @param opts.title - The opening sentance for the deprecation message. It should not contain a dot. "Deprecated" by default.
+ * @param opts.title - The opening sentence for the deprecation message. It should not contain a dot. "Deprecated" by default.
  */
 export function getDeprecationMessage(opts: {
   title?: string;
@@ -144,15 +144,13 @@ export function getDeprecationMessage(opts: {
 /**
  * Get a snippet (first line) of the deprecated documentation without jsdoc tags.
  *
- * @param title - The opening sentance for the deprecation message. It should not contain a dot. "Deprecated" by default.
- * @param deprecatedInfo
- * @param model
+ * @param opts.title - The opening sentence for the deprecation message. It should not contain a dot. "Deprecated" by default.
  */
-export function getDeprecationPlainTextSnippet(
-  title: string | undefined,
-  deprecatedInfo: UI5DeprecatedInfo,
-  model: UI5SemanticModel
-): string;
+export function getDeprecationPlainTextSnippet(opts: {
+  title?: string;
+  deprecatedInfo: UI5DeprecatedInfo;
+  model: UI5SemanticModel;
+}): string;
 
 /**
  * Convert jsdoc description to markdown format string

--- a/packages/logic-utils/src/api.ts
+++ b/packages/logic-utils/src/api.ts
@@ -17,3 +17,9 @@ export {
   getUI5PropertyByXMLAttributeKey,
   getUI5NodeFromXMLElementNamespace,
 } from "./utils/xml-node-to-ui5-node";
+export {
+  getDeprecationPlainTextSnippet,
+  getDeprecationMessage,
+  convertJSDocToMarkdown,
+  getLink,
+} from "./utils/documentation";

--- a/packages/logic-utils/src/utils/documentation.ts
+++ b/packages/logic-utils/src/utils/documentation.ts
@@ -123,7 +123,7 @@ function convertJSDoc(
     },
     { matcher: /<ul>/g, replacement: { markdown: "", plaintext: "" } },
     { matcher: /<\/ul>/g, replacement: { markdown: "\n\n", plaintext: "\n" } },
-    // TODO should we handled ordered lists (ol)?
+    // TODO should we handle ordered lists (ol)?
 
     // Code value
     {
@@ -158,7 +158,7 @@ function convertJSDoc(
     {
       matcher: /{@link (([^\s}]+)\s)?([^}]+)}/g,
       replacement: {
-        markdown: (all, _, type, text) => {
+        markdown: (all, _, type, text): string => {
           return `[${text}](${getLink(model, type ?? text)})`;
         },
         plaintext: "$3",

--- a/packages/logic-utils/src/utils/documentation.ts
+++ b/packages/logic-utils/src/utils/documentation.ts
@@ -1,0 +1,191 @@
+import {
+  UI5DeprecatedInfo,
+  UI5SemanticModel,
+} from "@ui5-language-assistant/semantic-model-types";
+import { ReplaceFunction, forEach, unescape } from "lodash";
+
+const MAX_SNIPPET_LENGTH = 500;
+
+export function getDeprecationPlainTextSnippet(
+  title: string | undefined,
+  deprecatedInfo: UI5DeprecatedInfo,
+  model: UI5SemanticModel
+): string {
+  let text = deprecatedInfo.text;
+  if (text !== undefined) {
+    text = convertJSDocToPlainText(text, model);
+    // Only take the first sentence.
+    // A sentence is defined by a dot followed by a whitespace character.
+    // TODO Should we allow the result to have more than 1 line? (If so, add "s" flag to the regex)
+    const matches = text.match(/^((?:.*?)\.)\s/);
+    if (matches !== null) {
+      text = matches[1];
+    }
+    // Limit the length of the snippet
+    if (text.length > MAX_SNIPPET_LENGTH) {
+      text = text.substring(0, MAX_SNIPPET_LENGTH) + "...";
+    }
+  }
+
+  const doc = getDeprecationMessage({
+    title,
+    since: deprecatedInfo.since,
+    text,
+  });
+  return doc;
+}
+
+export function getDeprecationMessage({
+  title,
+  since,
+  text,
+}: {
+  title?: string;
+  since: string | undefined;
+  text: string | undefined;
+}): string {
+  let contents = title ?? "Deprecated";
+  contents += since ? ` since version ${since}` : "";
+  contents += ".";
+  contents += text ? ` ${text}` : "";
+  return contents;
+}
+
+function convertJSDocToPlainText(
+  jsdocDescription: string,
+  model: UI5SemanticModel
+): string {
+  return convertJSDoc(jsdocDescription, "plaintext", model);
+}
+
+export function convertJSDocToMarkdown(
+  jsdocDescription: string,
+  model: UI5SemanticModel
+): string {
+  return convertJSDoc(jsdocDescription, "markdown", model);
+}
+
+type ConvertTarget = "markdown" | "plaintext";
+function convertJSDoc(
+  jsdoc: string,
+  target: ConvertTarget,
+  model: UI5SemanticModel
+): string {
+  // The replacements are applied in order
+  const tagMatcherToReplacement: {
+    matcher: RegExp;
+    replacement: Record<ConvertTarget, string | ReplaceFunction>;
+  }[] = [
+    // Italics
+    {
+      matcher: /<i>(.+?)<\/i>/g,
+      replacement: { markdown: "*$1*", plaintext: "$1" },
+    },
+
+    // Bold
+    {
+      matcher: /<b>(.+?)<\/b>/g,
+      replacement: { markdown: "**$1**", plaintext: "$1" },
+    },
+    {
+      matcher: /<strong>(.+?)<\/strong>/g,
+      replacement: { markdown: "**$1**", plaintext: "$1" },
+    },
+
+    // Emphasis
+    {
+      matcher: /<em>(.+?)<\/em>/g,
+      replacement: { markdown: "***$1***", plaintext: "$1" },
+    },
+
+    // Headers
+    {
+      matcher: /<h1>(.+?)<\/h1>/g,
+      replacement: { markdown: "\n# $1\n\n", plaintext: "\n$1\n" },
+    },
+    {
+      matcher: /<h2>(.+?)<\/h2>/g,
+      replacement: { markdown: "\n## $1\n\n", plaintext: "\n$1\n" },
+    },
+    {
+      matcher: /<h3>(.+?)<\/h3>/g,
+      replacement: { markdown: "\n### $1\n\n", plaintext: "\n$1\n" },
+    },
+    {
+      matcher: /<h4>(.+?)<\/h4>/g,
+      replacement: { markdown: "\n#### $1\n\n", plaintext: "\n$1\n" },
+    },
+
+    // Lists
+    {
+      matcher: /<li>(.+?)<\/li>/g,
+      replacement: { markdown: "\n* $1", plaintext: "\n* $1" },
+    },
+    { matcher: /<ul>/g, replacement: { markdown: "", plaintext: "" } },
+    { matcher: /<\/ul>/g, replacement: { markdown: "\n\n", plaintext: "\n" } },
+    // TODO should we handled ordered lists (ol)?
+
+    // Code value
+    {
+      matcher: /<code>(.+?)<\/code>/g,
+      replacement: { markdown: "`$1`", plaintext: "$1" },
+    },
+
+    // Code block
+    {
+      matcher: /<pre>([^]+?)<\/pre>/g,
+      replacement: {
+        markdown: "\n```javascript\n$1```\n",
+        plaintext: "\n$1\n",
+      },
+    },
+
+    // Line break
+    { matcher: /<br\/>/g, replacement: { markdown: "\n", plaintext: "\n" } },
+    { matcher: /<br>/g, replacement: { markdown: "\n", plaintext: "\n" } },
+    { matcher: /<\/br>/g, replacement: { markdown: "\n", plaintext: "\n" } },
+
+    // HTML Escaping, e.g. "&lt;View" --> "<View"
+    // Note: this doesn't replace all html-encoded characters, only the most common ones
+    {
+      matcher: /.*/gm,
+      replacement: { markdown: unescape, plaintext: unescape },
+    },
+
+    // Links
+    // Assuming links are of the form: {@link <type>[ <text>]}
+    // Where the type doesn't contain whitespace, and neither the type nor text contain the "}" character
+    {
+      matcher: /{@link (([^\s}]+)\s)?([^}]+)}/g,
+      replacement: {
+        markdown: (all, _, type, text) => {
+          return `[${text}](${getLink(model, type ?? text)})`;
+        },
+        plaintext: "$3",
+      },
+    },
+  ];
+
+  let contents = jsdoc;
+  forEach(tagMatcherToReplacement, (_) => {
+    const replacement = _.replacement[target];
+    // Workaround for typescript signature definition
+    if (typeof replacement === "string") {
+      contents = contents.replace(_.matcher, replacement);
+    } else {
+      contents = contents.replace(_.matcher, replacement);
+    }
+  });
+
+  return contents;
+}
+
+export function getLink(model: UI5SemanticModel, link: string): string {
+  if (link.startsWith("http:") || link.startsWith("https:")) {
+    return link;
+  }
+  if (model.version) {
+    return `https://sapui5.hana.ondemand.com/${model.version}/#/api/${link}`;
+  }
+  return `https://sapui5.hana.ondemand.com/#/api/${link}`;
+}

--- a/packages/logic-utils/src/utils/documentation.ts
+++ b/packages/logic-utils/src/utils/documentation.ts
@@ -178,16 +178,20 @@ function convertJSDoc(
 
   let contents = jsdoc;
   forEach(allTagMatcherToReplacement, (_) => {
-    const replacement = _.replacement[target];
-    // Workaround for typescript signature definition
-    if (typeof replacement === "string") {
-      contents = contents.replace(_.matcher, replacement);
-    } else {
-      contents = contents.replace(_.matcher, replacement);
-    }
+    contents = replace(contents, _.matcher, _.replacement[target]);
   });
 
   return contents;
+}
+
+function replace(
+  string: string,
+  matcher: RegExp,
+  replacement: string | ReplaceFunction
+): string {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  //@ts-ignore - 'replace' is defined with 2 overloads instead of a union type in the definitions file
+  return string.replace(matcher, replacement);
 }
 
 export function getLink(model: UI5SemanticModel, link: string): string {

--- a/packages/logic-utils/src/utils/documentation.ts
+++ b/packages/logic-utils/src/utils/documentation.ts
@@ -2,15 +2,19 @@ import {
   UI5DeprecatedInfo,
   UI5SemanticModel,
 } from "@ui5-language-assistant/semantic-model-types";
-import { ReplaceFunction, forEach, unescape } from "lodash";
+import { ReplaceFunction, forEach, unescape, concat } from "lodash";
 
 const MAX_SNIPPET_LENGTH = 500;
 
-export function getDeprecationPlainTextSnippet(
-  title: string | undefined,
-  deprecatedInfo: UI5DeprecatedInfo,
-  model: UI5SemanticModel
-): string {
+export function getDeprecationPlainTextSnippet({
+  title,
+  deprecatedInfo,
+  model,
+}: {
+  title?: string;
+  deprecatedInfo: UI5DeprecatedInfo;
+  model: UI5SemanticModel;
+}): string {
   let text = deprecatedInfo.text;
   if (text !== undefined) {
     text = convertJSDocToPlainText(text, model);
@@ -66,92 +70,98 @@ export function convertJSDocToMarkdown(
 }
 
 type ConvertTarget = "markdown" | "plaintext";
+
+// The replacements are applied in order
+const tagMatcherToReplacement: {
+  matcher: RegExp;
+  replacement: Record<ConvertTarget, string | ReplaceFunction>;
+}[] = [
+  // Italics
+  {
+    matcher: /<i>(.+?)<\/i>/g,
+    replacement: { markdown: "*$1*", plaintext: "$1" },
+  },
+
+  // Bold
+  {
+    matcher: /<b>(.+?)<\/b>/g,
+    replacement: { markdown: "**$1**", plaintext: "$1" },
+  },
+  {
+    matcher: /<strong>(.+?)<\/strong>/g,
+    replacement: { markdown: "**$1**", plaintext: "$1" },
+  },
+
+  // Emphasis
+  {
+    matcher: /<em>(.+?)<\/em>/g,
+    replacement: { markdown: "***$1***", plaintext: "$1" },
+  },
+
+  // Headers
+  {
+    matcher: /<h1>(.+?)<\/h1>/g,
+    replacement: { markdown: "\n# $1\n\n", plaintext: "\n$1\n" },
+  },
+  {
+    matcher: /<h2>(.+?)<\/h2>/g,
+    replacement: { markdown: "\n## $1\n\n", plaintext: "\n$1\n" },
+  },
+  {
+    matcher: /<h3>(.+?)<\/h3>/g,
+    replacement: { markdown: "\n### $1\n\n", plaintext: "\n$1\n" },
+  },
+  {
+    matcher: /<h4>(.+?)<\/h4>/g,
+    replacement: { markdown: "\n#### $1\n\n", plaintext: "\n$1\n" },
+  },
+
+  // Lists
+  {
+    matcher: /<li>(.+?)<\/li>/g,
+    replacement: { markdown: "\n* $1", plaintext: "\n* $1" },
+  },
+  { matcher: /<ul>/g, replacement: { markdown: "", plaintext: "" } },
+  { matcher: /<\/ul>/g, replacement: { markdown: "\n\n", plaintext: "\n" } },
+  // TODO should we handle ordered lists (ol)?
+
+  // Code value
+  {
+    matcher: /<code>(.+?)<\/code>/g,
+    replacement: { markdown: "`$1`", plaintext: "$1" },
+  },
+
+  // Code block
+  {
+    matcher: /<pre>([^]+?)<\/pre>/g,
+    replacement: {
+      markdown: "\n```javascript\n$1```\n",
+      plaintext: "\n$1\n",
+    },
+  },
+
+  // Line break
+  { matcher: /<br\/>/g, replacement: { markdown: "\n", plaintext: "\n" } },
+  { matcher: /<br>/g, replacement: { markdown: "\n", plaintext: "\n" } },
+  { matcher: /<\/br>/g, replacement: { markdown: "\n", plaintext: "\n" } },
+
+  // HTML Escaping, e.g. "&lt;View" --> "<View"
+  // Note: this doesn't replace all html-encoded characters, only the most common ones
+  {
+    matcher: /.*/gm,
+    replacement: { markdown: unescape, plaintext: unescape },
+  },
+];
+
 function convertJSDoc(
   jsdoc: string,
   target: ConvertTarget,
   model: UI5SemanticModel
 ): string {
-  // The replacements are applied in order
-  const tagMatcherToReplacement: {
-    matcher: RegExp;
-    replacement: Record<ConvertTarget, string | ReplaceFunction>;
-  }[] = [
-    // Italics
-    {
-      matcher: /<i>(.+?)<\/i>/g,
-      replacement: { markdown: "*$1*", plaintext: "$1" },
-    },
-
-    // Bold
-    {
-      matcher: /<b>(.+?)<\/b>/g,
-      replacement: { markdown: "**$1**", plaintext: "$1" },
-    },
-    {
-      matcher: /<strong>(.+?)<\/strong>/g,
-      replacement: { markdown: "**$1**", plaintext: "$1" },
-    },
-
-    // Emphasis
-    {
-      matcher: /<em>(.+?)<\/em>/g,
-      replacement: { markdown: "***$1***", plaintext: "$1" },
-    },
-
-    // Headers
-    {
-      matcher: /<h1>(.+?)<\/h1>/g,
-      replacement: { markdown: "\n# $1\n\n", plaintext: "\n$1\n" },
-    },
-    {
-      matcher: /<h2>(.+?)<\/h2>/g,
-      replacement: { markdown: "\n## $1\n\n", plaintext: "\n$1\n" },
-    },
-    {
-      matcher: /<h3>(.+?)<\/h3>/g,
-      replacement: { markdown: "\n### $1\n\n", plaintext: "\n$1\n" },
-    },
-    {
-      matcher: /<h4>(.+?)<\/h4>/g,
-      replacement: { markdown: "\n#### $1\n\n", plaintext: "\n$1\n" },
-    },
-
-    // Lists
-    {
-      matcher: /<li>(.+?)<\/li>/g,
-      replacement: { markdown: "\n* $1", plaintext: "\n* $1" },
-    },
-    { matcher: /<ul>/g, replacement: { markdown: "", plaintext: "" } },
-    { matcher: /<\/ul>/g, replacement: { markdown: "\n\n", plaintext: "\n" } },
-    // TODO should we handle ordered lists (ol)?
-
-    // Code value
-    {
-      matcher: /<code>(.+?)<\/code>/g,
-      replacement: { markdown: "`$1`", plaintext: "$1" },
-    },
-
-    // Code block
-    {
-      matcher: /<pre>([^]+?)<\/pre>/g,
-      replacement: {
-        markdown: "\n```javascript\n$1```\n",
-        plaintext: "\n$1\n",
-      },
-    },
-
-    // Line break
-    { matcher: /<br\/>/g, replacement: { markdown: "\n", plaintext: "\n" } },
-    { matcher: /<br>/g, replacement: { markdown: "\n", plaintext: "\n" } },
-    { matcher: /<\/br>/g, replacement: { markdown: "\n", plaintext: "\n" } },
-
-    // HTML Escaping, e.g. "&lt;View" --> "<View"
-    // Note: this doesn't replace all html-encoded characters, only the most common ones
-    {
-      matcher: /.*/gm,
-      replacement: { markdown: unescape, plaintext: unescape },
-    },
-
+  // We add replacements that require the model here (because they cannot be in tagMatcherToReplacement which is defined
+  // outside of the function).
+  // Note that they are applied after the replacements defined in tagMatcherToReplacement.
+  const allTagMatcherToReplacement = concat(tagMatcherToReplacement, [
     // Links
     // Assuming links are of the form: {@link <type>[ <text>]}
     // Where the type doesn't contain whitespace, and neither the type nor text contain the "}" character
@@ -164,10 +174,10 @@ function convertJSDoc(
         plaintext: "$3",
       },
     },
-  ];
+  ]);
 
   let contents = jsdoc;
-  forEach(tagMatcherToReplacement, (_) => {
+  forEach(allTagMatcherToReplacement, (_) => {
     const replacement = _.replacement[target];
     // Workaround for typescript signature definition
     if (typeof replacement === "string") {

--- a/packages/logic-utils/test/utils/documentation-spec.ts
+++ b/packages/logic-utils/test/utils/documentation-spec.ts
@@ -1,125 +1,123 @@
+import { expect } from "chai";
+import { padEnd } from "lodash";
+import { buildUI5Model } from "@ui5-language-assistant/test-utils";
 import {
   getDeprecationPlainTextSnippet,
   convertJSDocToMarkdown,
 } from "../../src/utils/documentation";
-import { expect } from "chai";
-import { buildUI5Model } from "@ui5-language-assistant/test-utils";
-import { padEnd } from "lodash";
+import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
 
 describe("The @ui5-language-assistant/logic-utils <getDeprecationPlainTextSnippet> function", () => {
-  const model = buildUI5Model({});
+  let model: UI5SemanticModel;
+  before(() => {
+    model = buildUI5Model({});
+  });
 
   it("returns a snippet without title, since and text", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        undefined,
-        {
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
           isDeprecated: true,
           since: undefined,
           text: undefined,
         },
-        model
-      )
+        model,
+      })
     ).to.equal("Deprecated.");
   });
 
   it("returns a snippet with title and without since and text", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        "This class is deprecated",
-        {
+      getDeprecationPlainTextSnippet({
+        title: "This class is deprecated",
+        deprecatedInfo: {
           isDeprecated: true,
           since: undefined,
           text: undefined,
         },
-        model
-      )
+        model,
+      })
     ).to.equal("This class is deprecated.");
   });
 
   it("returns a snippet with since and without text", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        undefined,
-        {
+      getDeprecationPlainTextSnippet({
+        title: undefined,
+        deprecatedInfo: {
           isDeprecated: true,
           since: "1.2.3",
           text: undefined,
         },
-        model
-      )
+        model,
+      })
     ).to.equal("Deprecated since version 1.2.3.");
   });
 
   it("returns a snippet without since and with text", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        undefined,
-        {
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
           isDeprecated: true,
           since: undefined,
           text: "Use something else instead.",
         },
-        model
-      )
+        model,
+      })
     ).to.equal("Deprecated. Use something else instead.");
   });
 
   it("returns a snippet with since and text", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        undefined,
-        {
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
           isDeprecated: true,
           since: "1.2.3",
           text: "Use something else instead.",
         },
-        model
-      )
+        model,
+      })
     ).to.equal("Deprecated since version 1.2.3. Use something else instead.");
   });
 
   context("text has jsdoc tags", () => {
     it("removes header tags", () => {
       expect(
-        getDeprecationPlainTextSnippet(
-          undefined,
-          {
+        getDeprecationPlainTextSnippet({
+          deprecatedInfo: {
             isDeprecated: true,
             since: undefined,
             text: "<h1>The Title</h1>",
           },
-          model
-        )
+          model,
+        })
       ).to.equal("Deprecated. \nThe Title\n");
     });
 
     it("replaces <br> tags with newline", () => {
       expect(
-        getDeprecationPlainTextSnippet(
-          undefined,
-          {
+        getDeprecationPlainTextSnippet({
+          deprecatedInfo: {
             isDeprecated: true,
             since: undefined,
             text: "The Title<br/>some text",
           },
-          model
-        )
+          model,
+        })
       ).to.equal("Deprecated. The Title\nsome text");
     });
 
     it("replaces link tags with their text", () => {
       expect(
-        getDeprecationPlainTextSnippet(
-          undefined,
-          {
+        getDeprecationPlainTextSnippet({
+          deprecatedInfo: {
             isDeprecated: true,
             since: undefined,
             text:
               "This text has a {@link the_address link with text} and a {@link link_without_text}",
           },
-          model
-        )
+          model,
+        })
       ).to.equal(
         "Deprecated. This text has a link with text and a link_without_text"
       );
@@ -128,51 +126,47 @@ describe("The @ui5-language-assistant/logic-utils <getDeprecationPlainTextSnippe
 
   it("only returns the first text sentence when the sentence is followed by a space", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        undefined,
-        {
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
           isDeprecated: true,
           since: undefined,
           text: "This text has two sentences. This is the second sentence.",
         },
-        model
-      )
+        model,
+      })
     ).to.equal("Deprecated. This text has two sentences.");
   });
 
   it("only returns the first text sentence when the sentence is followed by a newline", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        undefined,
-        {
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
           isDeprecated: true,
           since: undefined,
           text: "This text has two sentences.\nThis is the second line.",
         },
-        model
-      )
+        model,
+      })
     ).to.equal("Deprecated. This text has two sentences.");
   });
 
   it("only returns the first text sentence when the sentence is followed by a jsdoc <br> tag", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        undefined,
-        {
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
           isDeprecated: true,
           since: undefined,
           text: "This text has two sentences.<br/>This is the second line.",
         },
-        model
-      )
+        model,
+      })
     ).to.equal("Deprecated. This text has two sentences.");
   });
 
   it("only returns the first 500 characters of the text", () => {
     expect(
-      getDeprecationPlainTextSnippet(
-        undefined,
-        {
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
           isDeprecated: true,
           since: undefined,
           text: padEnd(
@@ -181,8 +175,8 @@ describe("The @ui5-language-assistant/logic-utils <getDeprecationPlainTextSnippe
             "1234567890"
           ),
         },
-        model
-      )
+        model,
+      })
     ).to.equal(
       "Deprecated. " +
         padEnd(
@@ -196,7 +190,10 @@ describe("The @ui5-language-assistant/logic-utils <getDeprecationPlainTextSnippe
 });
 
 describe("The @ui5-language-assistant/logic-utils <convertJSDocToMarkdown> function", () => {
-  const model = buildUI5Model({});
+  let model: UI5SemanticModel;
+  before(() => {
+    model = buildUI5Model({});
+  });
 
   it("replaces header tags", () => {
     expect(convertJSDocToMarkdown("<h1>The Title</h1>", model)).to.equal(

--- a/packages/logic-utils/test/utils/documentation-spec.ts
+++ b/packages/logic-utils/test/utils/documentation-spec.ts
@@ -1,9 +1,9 @@
 import { expect } from "chai";
-import { padEnd } from "lodash";
 import { buildUI5Model } from "@ui5-language-assistant/test-utils";
 import {
   getDeprecationPlainTextSnippet,
   convertJSDocToMarkdown,
+  convertJSDocToPlainText,
 } from "../../src/utils/documentation";
 import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
 
@@ -80,112 +80,67 @@ describe("The @ui5-language-assistant/logic-utils <getDeprecationPlainTextSnippe
     ).to.equal("Deprecated since version 1.2.3. Use something else instead.");
   });
 
-  context("text has jsdoc tags", () => {
-    it("removes header tags", () => {
-      expect(
-        getDeprecationPlainTextSnippet({
-          deprecatedInfo: {
-            isDeprecated: true,
-            since: undefined,
-            text: "<h1>The Title</h1>",
-          },
-          model,
-        })
-      ).to.equal("Deprecated. \nThe Title\n");
-    });
-
-    it("replaces <br> tags with newline", () => {
-      expect(
-        getDeprecationPlainTextSnippet({
-          deprecatedInfo: {
-            isDeprecated: true,
-            since: undefined,
-            text: "The Title<br/>some text",
-          },
-          model,
-        })
-      ).to.equal("Deprecated. The Title\nsome text");
-    });
-
-    it("replaces link tags with their text", () => {
-      expect(
-        getDeprecationPlainTextSnippet({
-          deprecatedInfo: {
-            isDeprecated: true,
-            since: undefined,
-            text:
-              "This text has a {@link the_address link with text} and a {@link link_without_text}",
-          },
-          model,
-        })
-      ).to.equal(
-        "Deprecated. This text has a link with text and a link_without_text"
-      );
-    });
-  });
-
-  it("only returns the first text sentence when the sentence is followed by a space", () => {
+  it("replaces link tags with their text", () => {
     expect(
       getDeprecationPlainTextSnippet({
         deprecatedInfo: {
           isDeprecated: true,
           since: undefined,
-          text: "This text has two sentences. This is the second sentence.",
-        },
-        model,
-      })
-    ).to.equal("Deprecated. This text has two sentences.");
-  });
-
-  it("only returns the first text sentence when the sentence is followed by a newline", () => {
-    expect(
-      getDeprecationPlainTextSnippet({
-        deprecatedInfo: {
-          isDeprecated: true,
-          since: undefined,
-          text: "This text has two sentences.\nThis is the second line.",
-        },
-        model,
-      })
-    ).to.equal("Deprecated. This text has two sentences.");
-  });
-
-  it("only returns the first text sentence when the sentence is followed by a jsdoc <br> tag", () => {
-    expect(
-      getDeprecationPlainTextSnippet({
-        deprecatedInfo: {
-          isDeprecated: true,
-          since: undefined,
-          text: "This text has two sentences.<br/>This is the second line.",
-        },
-        model,
-      })
-    ).to.equal("Deprecated. This text has two sentences.");
-  });
-
-  it("only returns the first 500 characters of the text", () => {
-    expect(
-      getDeprecationPlainTextSnippet({
-        deprecatedInfo: {
-          isDeprecated: true,
-          since: undefined,
-          text: padEnd(
-            "This text only has one sentence but it is VERY long: ",
-            700,
-            "1234567890"
-          ),
+          text:
+            "This text has a {@link the_address link with text} and a {@link link_without_text}",
         },
         model,
       })
     ).to.equal(
-      "Deprecated. " +
-        padEnd(
-          "This text only has one sentence but it is VERY long: ",
-          500,
-          "1234567890"
-        ) +
-        "..."
+      "Deprecated. This text has a link with text and a link_without_text"
     );
+  });
+
+  it("only returns the first text line when there is a linebreak", () => {
+    expect(
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
+          isDeprecated: true,
+          since: undefined,
+          text: "This text has two lines\nThis is the second line.",
+        },
+        model,
+      })
+    ).to.equal("Deprecated. This text has two lines ...");
+  });
+
+  it("only returns the first text line when there is a tag that is converted to linebreak", () => {
+    expect(
+      getDeprecationPlainTextSnippet({
+        deprecatedInfo: {
+          isDeprecated: true,
+          since: undefined,
+          text: "This text has two lines<br>This is the second line.",
+        },
+        model,
+      })
+    ).to.equal("Deprecated. This text has two lines ...");
+  });
+});
+
+describe("The @ui5-language-assistant/logic-utils <convertJSDocToMarkdown> function", () => {
+  let model: UI5SemanticModel;
+  before(() => {
+    model = buildUI5Model({});
+  });
+
+  context("text has jsdoc tags", () => {
+    it("removes header tags", () => {
+      expect(convertJSDocToPlainText("<h1>The Title</h1>", model)).to.equal(
+        "\nThe Title\n"
+      );
+    });
+
+    it("replaces <br> tags with newline", () => {
+      expect(
+        convertJSDocToPlainText("The Title<br/>some text", model)
+      ).to.equal("The Title\nsome text");
+    });
   });
 });
 

--- a/packages/logic-utils/test/utils/documentation-spec.ts
+++ b/packages/logic-utils/test/utils/documentation-spec.ts
@@ -1,0 +1,252 @@
+import {
+  getDeprecationPlainTextSnippet,
+  convertJSDocToMarkdown,
+} from "../../src/utils/documentation";
+import { expect } from "chai";
+import { buildUI5Model } from "@ui5-language-assistant/test-utils";
+import { padEnd } from "lodash";
+
+describe("The @ui5-language-assistant/logic-utils <getDeprecationPlainTextSnippet> function", () => {
+  const model = buildUI5Model({});
+
+  it("returns a snippet without title, since and text", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        undefined,
+        {
+          isDeprecated: true,
+          since: undefined,
+          text: undefined,
+        },
+        model
+      )
+    ).to.equal("Deprecated.");
+  });
+
+  it("returns a snippet with title and without since and text", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        "This class is deprecated",
+        {
+          isDeprecated: true,
+          since: undefined,
+          text: undefined,
+        },
+        model
+      )
+    ).to.equal("This class is deprecated.");
+  });
+
+  it("returns a snippet with since and without text", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        undefined,
+        {
+          isDeprecated: true,
+          since: "1.2.3",
+          text: undefined,
+        },
+        model
+      )
+    ).to.equal("Deprecated since version 1.2.3.");
+  });
+
+  it("returns a snippet without since and with text", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        undefined,
+        {
+          isDeprecated: true,
+          since: undefined,
+          text: "Use something else instead.",
+        },
+        model
+      )
+    ).to.equal("Deprecated. Use something else instead.");
+  });
+
+  it("returns a snippet with since and text", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        undefined,
+        {
+          isDeprecated: true,
+          since: "1.2.3",
+          text: "Use something else instead.",
+        },
+        model
+      )
+    ).to.equal("Deprecated since version 1.2.3. Use something else instead.");
+  });
+
+  context("text has jsdoc tags", () => {
+    it("removes header tags", () => {
+      expect(
+        getDeprecationPlainTextSnippet(
+          undefined,
+          {
+            isDeprecated: true,
+            since: undefined,
+            text: "<h1>The Title</h1>",
+          },
+          model
+        )
+      ).to.equal("Deprecated. \nThe Title\n");
+    });
+
+    it("replaces <br> tags with newline", () => {
+      expect(
+        getDeprecationPlainTextSnippet(
+          undefined,
+          {
+            isDeprecated: true,
+            since: undefined,
+            text: "The Title<br/>some text",
+          },
+          model
+        )
+      ).to.equal("Deprecated. The Title\nsome text");
+    });
+
+    it("replaces link tags with their text", () => {
+      expect(
+        getDeprecationPlainTextSnippet(
+          undefined,
+          {
+            isDeprecated: true,
+            since: undefined,
+            text:
+              "This text has a {@link the_address link with text} and a {@link link_without_text}",
+          },
+          model
+        )
+      ).to.equal(
+        "Deprecated. This text has a link with text and a link_without_text"
+      );
+    });
+  });
+
+  it("only returns the first text sentence when the sentence is followed by a space", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        undefined,
+        {
+          isDeprecated: true,
+          since: undefined,
+          text: "This text has two sentences. This is the second sentence.",
+        },
+        model
+      )
+    ).to.equal("Deprecated. This text has two sentences.");
+  });
+
+  it("only returns the first text sentence when the sentence is followed by a newline", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        undefined,
+        {
+          isDeprecated: true,
+          since: undefined,
+          text: "This text has two sentences.\nThis is the second line.",
+        },
+        model
+      )
+    ).to.equal("Deprecated. This text has two sentences.");
+  });
+
+  it("only returns the first text sentence when the sentence is followed by a jsdoc <br> tag", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        undefined,
+        {
+          isDeprecated: true,
+          since: undefined,
+          text: "This text has two sentences.<br/>This is the second line.",
+        },
+        model
+      )
+    ).to.equal("Deprecated. This text has two sentences.");
+  });
+
+  it("only returns the first 500 characters of the text", () => {
+    expect(
+      getDeprecationPlainTextSnippet(
+        undefined,
+        {
+          isDeprecated: true,
+          since: undefined,
+          text: padEnd(
+            "This text only has one sentence but it is VERY long: ",
+            700,
+            "1234567890"
+          ),
+        },
+        model
+      )
+    ).to.equal(
+      "Deprecated. " +
+        padEnd(
+          "This text only has one sentence but it is VERY long: ",
+          500,
+          "1234567890"
+        ) +
+        "..."
+    );
+  });
+});
+
+describe("The @ui5-language-assistant/logic-utils <convertJSDocToMarkdown> function", () => {
+  const model = buildUI5Model({});
+
+  it("replaces header tags", () => {
+    expect(convertJSDocToMarkdown("<h1>The Title</h1>", model)).to.equal(
+      "\n# The Title\n\n"
+    );
+  });
+
+  it("replaces <br> tags with newline", () => {
+    expect(convertJSDocToMarkdown("The Title<br/>some text", model)).to.equal(
+      "The Title\nsome text"
+    );
+  });
+
+  it("replaces link tags with markdown links", () => {
+    expect(
+      convertJSDocToMarkdown(
+        "This text has a {@link http://my.link link with text} and a {@link https://link.without.text}",
+        model
+      )
+    ).to.equal(
+      "This text has a [link with text](http://my.link) and a [https://link.without.text](https://link.without.text)"
+    );
+  });
+
+  it("replaces link tags that point to UI5 classes with markdown links when model has a version", () => {
+    const modelWithVersion = buildUI5Model({ version: "1.2.3" });
+    expect(
+      convertJSDocToMarkdown(
+        "This text has a {@link sap.m.Button link to Button} and a nameless link to a type: {@link sap.m.Button}",
+        modelWithVersion
+      )
+    ).to.equal(
+      "This text has a [link to Button](https://sapui5.hana.ondemand.com/1.2.3/#/api/sap.m.Button) and a nameless link to a type: [sap.m.Button](https://sapui5.hana.ondemand.com/1.2.3/#/api/sap.m.Button)"
+    );
+  });
+
+  it("replaces link tags that point to UI5 classes with markdown links when model doesn't have a version", () => {
+    expect(
+      convertJSDocToMarkdown(
+        "This text has a {@link sap.m.Button link to Button} and a nameless link to a type: {@link sap.m.Button}",
+        model
+      )
+    ).to.equal(
+      "This text has a [link to Button](https://sapui5.hana.ondemand.com/#/api/sap.m.Button) and a nameless link to a type: [sap.m.Button](https://sapui5.hana.ondemand.com/#/api/sap.m.Button)"
+    );
+  });
+
+  it("unescapes html entities after replacing tags", () => {
+    expect(
+      convertJSDocToMarkdown("This text has a <br> and a &lt;br&gt;", model)
+    ).to.equal("This text has a \n and a <br>");
+  });
+});

--- a/packages/xml-views-validation/src/utils/deprecated-message-builder.ts
+++ b/packages/xml-views-validation/src/utils/deprecated-message-builder.ts
@@ -32,9 +32,9 @@ export function buildDeprecatedIssueMessage({
       assertNever(symbol.kind);
   }
   const msgPrefix = `The ${name} ${kind} is deprecated`;
-  return getDeprecationPlainTextSnippet(
-    msgPrefix,
-    symbol.deprecatedInfo,
-    model
-  );
+  return getDeprecationPlainTextSnippet({
+    title: msgPrefix,
+    deprecatedInfo: symbol.deprecatedInfo,
+    model,
+  });
 }

--- a/packages/xml-views-validation/src/utils/deprecated-message-builder.ts
+++ b/packages/xml-views-validation/src/utils/deprecated-message-builder.ts
@@ -27,6 +27,7 @@ export function buildDeprecatedIssueMessage({
       kind = "class";
       name = ui5NodeToFQN(symbol);
       break;
+    /* istanbul ignore next - defensive programming */
     default:
       assertNever(symbol.kind);
   }

--- a/packages/xml-views-validation/src/utils/deprecated-message-builder.ts
+++ b/packages/xml-views-validation/src/utils/deprecated-message-builder.ts
@@ -1,23 +1,39 @@
-import { UI5DeprecatedInfo } from "@ui5-language-assistant/semantic-model-types";
+import { assertNever } from "assert-never";
+import {
+  UI5DeprecatedInfo,
+  UI5SemanticModel,
+  UI5Class,
+} from "@ui5-language-assistant/semantic-model-types";
+import {
+  getDeprecationPlainTextSnippet,
+  ui5NodeToFQN,
+} from "@ui5-language-assistant/logic-utils";
 
-// TODO: unit tests for all edge cases
-export function buildDeprecatedIssueMessage({
-  ui5Kind,
-  fqn,
-  deprecatedInfo,
-}: {
-  // TODO: add more kinds here as needed (e.g property/aggregation/...)
-  ui5Kind: "Class";
-  fqn: string;
+// TODO: add more types here as needed (e.g property/aggregation/...)
+export type DeprecatedUI5Symbol = {
   deprecatedInfo: UI5DeprecatedInfo;
+} & UI5Class;
+export function buildDeprecatedIssueMessage({
+  symbol,
+  model,
+}: {
+  symbol: DeprecatedUI5Symbol;
+  model: UI5SemanticModel;
 }): string {
-  const msgPrefix = `UI5 ${ui5Kind} ${fqn} is deprecated`;
-  const sinceOptionalPart = deprecatedInfo.since
-    ? ` since: ${deprecatedInfo.since}`
-    : "";
-  const detailsOptionalPart = deprecatedInfo.text
-    ? `\n\t${deprecatedInfo.text}.`
-    : "";
-
-  return `${msgPrefix}${sinceOptionalPart}.${detailsOptionalPart}`;
+  let kind: string;
+  let name: string;
+  switch (symbol.kind) {
+    case "UI5Class":
+      kind = "class";
+      name = ui5NodeToFQN(symbol);
+      break;
+    default:
+      assertNever(symbol.kind);
+  }
+  const msgPrefix = `The ${name} ${kind} is deprecated`;
+  return getDeprecationPlainTextSnippet(
+    msgPrefix,
+    symbol.deprecatedInfo,
+    model
+  );
 }

--- a/packages/xml-views-validation/src/validators/elements/use-of-deprecated-class.ts
+++ b/packages/xml-views-validation/src/validators/elements/use-of-deprecated-class.ts
@@ -1,9 +1,6 @@
 import { XMLElement } from "@xml-tools/ast";
 import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
-import {
-  getUI5ClassByXMLElement,
-  ui5NodeToFQN,
-} from "@ui5-language-assistant/logic-utils";
+import { getUI5ClassByXMLElement } from "@ui5-language-assistant/logic-utils";
 import { UseOfDeprecatedClassIssue } from "../../../api";
 import {
   buildDeprecatedIssueMessage,

--- a/packages/xml-views-validation/src/validators/elements/use-of-deprecated-class.ts
+++ b/packages/xml-views-validation/src/validators/elements/use-of-deprecated-class.ts
@@ -5,7 +5,10 @@ import {
   ui5NodeToFQN,
 } from "@ui5-language-assistant/logic-utils";
 import { UseOfDeprecatedClassIssue } from "../../../api";
-import { buildDeprecatedIssueMessage } from "../../utils/deprecated-message-builder";
+import {
+  buildDeprecatedIssueMessage,
+  DeprecatedUI5Symbol,
+} from "../../utils/deprecated-message-builder";
 
 export function validateUseOfDeprecatedClass(
   xmlElement: XMLElement,
@@ -21,13 +24,11 @@ export function validateUseOfDeprecatedClass(
     // An issue lacking a position is not a useful issue...
     xmlElement.syntax.openName !== undefined
   ) {
-    const deprecatedInfo = ui5Class.deprecatedInfo;
     const deprecatedIssue: UseOfDeprecatedClassIssue = {
       kind: "UseOfDeprecatedClass",
       message: buildDeprecatedIssueMessage({
-        deprecatedInfo: deprecatedInfo,
-        fqn: ui5NodeToFQN(ui5Class),
-        ui5Kind: "Class",
+        symbol: ui5Class as DeprecatedUI5Symbol,
+        model,
       }),
       severity: "warn",
       offsetRange: {

--- a/packages/xml-views-validation/test/utils/deprecated-message-builder-spec.ts
+++ b/packages/xml-views-validation/test/utils/deprecated-message-builder-spec.ts
@@ -1,62 +1,82 @@
 import { expect } from "chai";
-import { buildUI5DeprecatedInfo } from "@ui5-language-assistant/test-utils/";
+import {
+  buildUI5DeprecatedInfo,
+  buildUI5Model,
+  buildUI5Class,
+  buildUI5Namespace,
+} from "@ui5-language-assistant/test-utils/";
 import { buildDeprecatedIssueMessage } from "../../src/utils/deprecated-message-builder";
 
 describe("the deprecated message builder", () => {
+  const model = buildUI5Model({});
+  const osem = buildUI5Namespace({ name: "osem" });
+
   it("can build a full message with 'since' and 'details'", () => {
-    const deprecatedInfo = buildUI5DeprecatedInfo({
-      text: "use osem.Bamba instead",
-      since: "version 6.6.6",
+    const ui5Class = buildUI5Class({
+      parent: osem,
+      name: "Bisli",
+      deprecatedInfo: buildUI5DeprecatedInfo({
+        text: "use osem.Bamba instead.",
+        since: "6.6.6",
+      }),
     });
 
     const actualMessage = buildDeprecatedIssueMessage({
-      ui5Kind: "Class",
-      fqn: "osem.Bisli",
-      deprecatedInfo,
+      symbol: ui5Class,
+      model,
     });
     expect(actualMessage).to.eql(
-      "UI5 Class osem.Bisli is deprecated since: version 6.6.6.\n\tuse osem.Bamba instead."
+      "The osem.Bisli class is deprecated since version 6.6.6. use osem.Bamba instead."
     );
   });
 
   it("can build a message with only the prefix", () => {
-    const deprecatedInfo = buildUI5DeprecatedInfo({});
+    const ui5Class = buildUI5Class({
+      parent: osem,
+      name: "Bisli",
+      deprecatedInfo: buildUI5DeprecatedInfo({}),
+    });
 
     const actualMessage = buildDeprecatedIssueMessage({
-      ui5Kind: "Class",
-      fqn: "osem.Bisli",
-      deprecatedInfo,
+      symbol: ui5Class,
+      model,
     });
-    expect(actualMessage).to.eql("UI5 Class osem.Bisli is deprecated.");
+    expect(actualMessage).to.eql("The osem.Bisli class is deprecated.");
   });
 
   it("can build a message with only the prefix and the `since` info", () => {
-    const deprecatedInfo = buildUI5DeprecatedInfo({
-      since: "version 6.6.6",
+    const ui5Class = buildUI5Class({
+      parent: osem,
+      name: "Bisli",
+      deprecatedInfo: buildUI5DeprecatedInfo({
+        since: "6.6.6",
+      }),
     });
 
     const actualMessage = buildDeprecatedIssueMessage({
-      ui5Kind: "Class",
-      fqn: "osem.Bisli",
-      deprecatedInfo,
+      symbol: ui5Class,
+      model,
     });
     expect(actualMessage).to.eql(
-      "UI5 Class osem.Bisli is deprecated since: version 6.6.6."
+      "The osem.Bisli class is deprecated since version 6.6.6."
     );
   });
 
   it("can build a message with only the prefix and the `details` info", () => {
-    const deprecatedInfo = buildUI5DeprecatedInfo({
-      text: "use osem.Bamba instead",
+    const ui5Class = buildUI5Class({
+      parent: osem,
+      name: "Bisli",
+      deprecatedInfo: buildUI5DeprecatedInfo({
+        text: "use osem.Bamba instead.",
+      }),
     });
 
     const actualMessage = buildDeprecatedIssueMessage({
-      ui5Kind: "Class",
-      fqn: "osem.Bisli",
-      deprecatedInfo,
+      symbol: ui5Class,
+      model,
     });
     expect(actualMessage).to.eql(
-      "UI5 Class osem.Bisli is deprecated.\n\tuse osem.Bamba instead."
+      "The osem.Bisli class is deprecated. use osem.Bamba instead."
     );
   });
 });

--- a/packages/xml-views-validation/test/validators/element/use-of-deprecated-class-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/use-of-deprecated-class-spec.ts
@@ -40,7 +40,7 @@ describe("the use of deprecated class validation", () => {
             {
               kind: "UseOfDeprecatedClass",
               message:
-                "UI5 Class sap.ui.commons.Button is deprecated since: 1.38.\n\treplaced by {@link sap.m.Button}.",
+                "The sap.ui.commons.Button class is deprecated since version 1.38. replaced by sap.m.Button",
               severity: "warn",
               offsetRange: computeExpectedRange(xmlSnippet),
             },
@@ -72,7 +72,7 @@ describe("the use of deprecated class validation", () => {
             {
               kind: "UseOfDeprecatedClass",
               message:
-                "UI5 Class sap.ui.commons.Button is deprecated since: 1.38.\n\treplaced by {@link sap.m.Button}.",
+                "The sap.ui.commons.Button class is deprecated since version 1.38. replaced by sap.m.Button",
               severity: "warn",
               offsetRange: computeExpectedRange(xmlSnippet),
             },
@@ -105,7 +105,7 @@ describe("the use of deprecated class validation", () => {
             {
               kind: "UseOfDeprecatedClass",
               message:
-                "UI5 Class sap.ui.commons.Button is deprecated since: 1.38.\n\treplaced by {@link sap.m.Button}.",
+                "The sap.ui.commons.Button class is deprecated since version 1.38. replaced by sap.m.Button",
               severity: "warn",
               offsetRange: computeExpectedRange(xmlSnippet),
             },

--- a/test-packages/test-utils/api.d.ts
+++ b/test-packages/test-utils/api.d.ts
@@ -24,7 +24,9 @@ import { FetchResponse } from "@ui5-language-assistant/language-server";
 //	easily build (partial) data structures for tests with mandatory "name" field
 export type PartialWithName<T> = { name: string } & Partial<T>;
 
-export function buildUI5Class(opts: PartialWithName<UI5Class>): UI5Class;
+export function buildUI5Class<T extends PartialWithName<UI5Class>>(
+  opts: T
+): UI5Class & T;
 
 export function buildUI5Interface(
   opts: PartialWithName<UI5Interface>

--- a/test-packages/test-utils/src/utils/semantic-model-builder.ts
+++ b/test-packages/test-utils/src/utils/semantic-model-builder.ts
@@ -100,7 +100,9 @@ export function buildUI5Association(
   };
 }
 
-export function buildUI5Class(opts: PartialWithName<UI5Class>): UI5Class {
+export function buildUI5Class<T extends PartialWithName<UI5Class>>(
+  opts: T
+): UI5Class & T {
   return {
     ...baseUI5NodeDefaults,
     abstract: false,


### PR DESCRIPTION
Move some documentation functions to logic-utils and add tests