### PR TITLE
fix(xml-views-validation): avoid false positive errors for unknown tags

### DIFF
--- a/packages/logic-utils/api.d.ts
+++ b/packages/logic-utils/api.d.ts
@@ -9,6 +9,7 @@ import {
   UI5Association,
   UI5SemanticModel,
   UI5Type,
+  UI5Namespace,
 } from "@ui5-language-assistant/semantic-model-types";
 
 /**
@@ -86,8 +87,6 @@ export function typeToString(type: UI5Type | undefined): string;
 
 /**
  * Return the UI5 Class for an XML Element
- * @param element
- * @param model
  */
 export function getUI5ClassByXMLElement(
   element: XMLElement,
@@ -96,8 +95,6 @@ export function getUI5ClassByXMLElement(
 
 /**
  * Return the UI5 Aggregation for an XML Element
- * @param element
- * @param model
  */
 export function getUI5AggregationByXMLElement(
   element: XMLElement,
@@ -106,8 +103,6 @@ export function getUI5AggregationByXMLElement(
 
 /**
  * Return the UI5 Property for an XML Attribute
- * @param attribute
- * @param model
  */
 export function getUI5PropertyByXMLAttributeKey(
   attribute: XMLAttribute,
@@ -116,15 +111,12 @@ export function getUI5PropertyByXMLAttributeKey(
 
 /**
  * Return the UI5 Namespace from the specified or default XML Element namespace
- *
- * @param xmlElement
- * @param model
  */
 export function getUI5NodeFromXMLElementNamespace(
   xmlElement: XMLElement,
   model: UI5SemanticModel
 ): {
-  namespace: BaseUI5Node | undefined;
+  namespace: UI5Namespace | undefined;
   isDefault: boolean;
   isXmlnsDefined: boolean;
 };

--- a/packages/logic-utils/src/utils/xml-node-to-ui5-node.ts
+++ b/packages/logic-utils/src/utils/xml-node-to-ui5-node.ts
@@ -9,10 +9,9 @@ import {
   UI5SemanticModel,
   UI5Prop,
   UI5Aggregation,
-  BaseUI5Node,
+  UI5Namespace,
 } from "@ui5-language-assistant/semantic-model-types";
 import { find } from "lodash";
-import { findSymbol } from "@ui5-language-assistant/semantic-model";
 
 export function getUI5ClassByXMLElement(
   element: XMLElement,
@@ -30,7 +29,7 @@ export function getUI5AggregationByXMLElement(
   if (element.parent.type === "XMLDocument") {
     return undefined;
   }
-  // Aggregations don't have a namesapce
+  // Aggregations don't have a namespace
   if (element.ns !== undefined) {
     return undefined;
   }
@@ -61,13 +60,13 @@ export function getUI5NodeFromXMLElementNamespace(
   xmlElement: XMLElement,
   model: UI5SemanticModel
 ): {
-  namespace: BaseUI5Node | undefined;
+  namespace: UI5Namespace | undefined;
   isDefault: boolean;
   isXmlnsDefined: boolean;
 } {
   const isDefault = xmlElement.ns === undefined;
-  const xmlNamespace = xmlElement.namespaces[xmlElement.ns ?? DEFAULT_NS];
-  if (xmlNamespace === undefined) {
+  const xmlnsFQN = xmlElement.namespaces[xmlElement.ns ?? DEFAULT_NS];
+  if (xmlnsFQN === undefined) {
     return {
       namespace: undefined,
       isDefault: isDefault,
@@ -75,7 +74,7 @@ export function getUI5NodeFromXMLElementNamespace(
     };
   }
 
-  const ui5Namespace = findSymbol(model, xmlNamespace);
+  const ui5Namespace = model.namespaces[xmlnsFQN];
   return {
     namespace: ui5Namespace,
     isDefault: isDefault,

--- a/packages/logic-utils/test/utils/xml-node-to-ui5-node-spec.ts
+++ b/packages/logic-utils/test/utils/xml-node-to-ui5-node-spec.ts
@@ -242,7 +242,7 @@ describe("The @ui5-language-assistant/logic-utils <getUI5NodeFromXMLElementNames
     expect(ui5NodeToFQN(ui5Node)).to.equal("sap.ui.core.mvc");
   });
 
-  it("returns the namespace for tag in a defined namespace when namespace points to an enum", () => {
+  it("returns the undefined for tag in a defined namespace when namespace points to an enum", () => {
     const xmlText = `
         <mvc:View xmlns:mvc="sap.ui.core.BusyIndicatorSize">
         </mvc:View>`;
@@ -255,8 +255,7 @@ describe("The @ui5-language-assistant/logic-utils <getUI5NodeFromXMLElementNames
     } = getUI5NodeFromXMLElementNamespace(rootElement, ui5Model);
     expect(isDefault).to.be.false;
     expect(isXmlnsDefined).to.be.true;
-    expectExists(ui5Node, "ui5 namespace");
-    expect(ui5NodeToFQN(ui5Node)).to.equal("sap.ui.core.BusyIndicatorSize");
+    expect(ui5Node, "ui5 namespace").to.be.undefined;
   });
 
   it("returns undefined for tag in a defined unknown namespace", () => {

--- a/packages/xml-views-validation/test/validators/element/unknown-tag-name-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/unknown-tag-name-spec.ts
@@ -310,6 +310,18 @@ describe("the unknown tag name validation", () => {
             </mvc:View>`
           );
         });
+
+        it("will not detect an issue for a class under an none existent namespace which is also a valid UI5 entity FQN", () => {
+          assertNoIssues(
+            `<mvc:View
+              xmlns:mvc="sap.ui.core.mvc"
+              <!-- The error should be on the definition of an invalid xmlns which is not a UI5Namespace rather than on each usage -->
+              xmlns:AvatarColor="sap.m.AvatarColor">
+              <AvatarColor:Green>
+              </AvatarColor:Green>
+            </mvc:View>`
+          );
+        });
       });
     });
 


### PR DESCRIPTION
If an unknown tag was under a none namespace UI5 entity fqn, e.g the FQN of an enum/interface it
would be treated as a valid known namespace and thus an error would occur.