### PR TITLE
fix: don't offer classes from sub-namespaces in code completion

### DIFF
--- a/packages/xml-views-completion/test/providers/elementName/classes-spec.ts
+++ b/packages/xml-views-completion/test/providers/elementName/classes-spec.ts
@@ -349,6 +349,9 @@ describe("The ui5-language-assistant xml-views-completion", () => {
                   expect(suggestionNames).to.deep.equalInAnyOrder([
                     "sap.ui.core.ComponentContainer",
                   ]);
+                  expect(suggestionNames).to.not.include(
+                    "sap.ui.core.tmpl.TemplateControl"
+                  );
                 },
               });
             });
@@ -420,6 +423,9 @@ describe("The ui5-language-assistant xml-views-completion", () => {
                       "sap.ui.core.LocalBusyIndicator",
                       "sap.ui.core.ScrollBar",
                     ]);
+                    expect(suggestionNames).to.not.include(
+                      "sap.ui.core.mvc.View"
+                    );
                   },
                 });
               });

--- a/packages/xml-views-completion/test/providers/elementName/classes-spec.ts
+++ b/packages/xml-views-completion/test/providers/elementName/classes-spec.ts
@@ -323,6 +323,35 @@ describe("The ui5-language-assistant xml-views-completion", () => {
                 },
               });
             });
+
+            it("will only suggest classes from the specified namespace and not its sub-namespace", () => {
+              const xmlSnippet = `
+                <mvc:View
+                  xmlns:mvc="sap.ui.core.mvc"
+                  xmlns:core="sap.ui.core"
+                  >
+                  <mvc:content>
+                    <core:Con⇶
+                  </mvc:content>
+                </mvc:View>`;
+
+              testSuggestionsScenario({
+                model: ui5Model,
+                xmlText: xmlSnippet,
+                providers: {
+                  elementName: [classesSuggestions],
+                },
+                assertion: (suggestions) => {
+                  assertSuggestionProperties(suggestions, "content");
+                  const suggestionNames = map(suggestions, (_) =>
+                    ui5NodeToFQN(_.ui5Node)
+                  );
+                  expect(suggestionNames).to.deep.equalInAnyOrder([
+                    "sap.ui.core.ComponentContainer",
+                  ]);
+                },
+              });
+            });
           });
 
           context(
@@ -356,6 +385,40 @@ describe("The ui5-language-assistant xml-views-completion", () => {
                     expect(suggestionNames).to.deep.equalInAnyOrder([
                       "sap.ui.commons.form.GridContainerData",
                       "sap.ui.commons.form.GridElementData",
+                    ]);
+                  },
+                });
+              });
+
+              it("will only suggest classes from the specified namespace and not its sub-namespaces", () => {
+                const xmlSnippet = `
+                  <mvc:View
+                    xmlns:mvc="sap.ui.core.mvc"
+                    xmlns:core="sap.ui.core"
+                    >
+                    <mvc:content>
+                      <core:⇶
+                    </mvc:content>
+                  </mvc:View>`;
+
+                testSuggestionsScenario({
+                  model: ui5Model,
+                  xmlText: xmlSnippet,
+                  providers: {
+                    elementName: [classesSuggestions],
+                  },
+                  assertion: (suggestions) => {
+                    assertSuggestionProperties(suggestions, "content");
+                    const suggestionNames = map(suggestions, (_) =>
+                      ui5NodeToFQN(_.ui5Node)
+                    );
+                    expect(suggestionNames).to.deep.equalInAnyOrder([
+                      "sap.ui.core.ComponentContainer",
+                      "sap.ui.core.HTML",
+                      "sap.ui.core.Icon",
+                      "sap.ui.core.InvisibleText",
+                      "sap.ui.core.LocalBusyIndicator",
+                      "sap.ui.core.ScrollBar",
                     ]);
                   },
                 });


### PR DESCRIPTION
Use utility function to split the element name and namespace prefix.