### PR TITLE
chore: add sub-packages LICENSE to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 # sub-packages files for https://reuse.software (avoid duplication)
 .reuse
 LICENSES
+LICENSE
 
 # root files for https://reuse.software
 !/.reuse
 !/LICENSES
+!/LICENSE
 
 # Logs
 logs


### PR DESCRIPTION
Add sub-packages LICENSE to gitignore as they are generated during build.