### PR TITLE
fix(language-server): detect the UI5 version from closest manifest.json

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@types/node-fetch": "2.5.10",
+    "@types/semver": "7.3.12",
     "@types/tmp": "0.2.0",
     "@ui5-language-assistant/semantic-model-types": "^3.2.0",
     "@ui5-language-assistant/test-utils": "^3.2.0",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -41,7 +41,7 @@
     "fs-extra": "9.0.1",
     "lodash": "4.17.21",
     "node-fetch": "2.6.1",
-    "semver": "^7.3.7",
+    "semver": "7.3.7",
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-textdocument": "1.0.1",
     "vscode-uri": "2.1.2"

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -41,10 +41,10 @@
     "fs-extra": "9.0.1",
     "lodash": "4.17.21",
     "node-fetch": "2.6.1",
+    "semver": "^7.3.7",
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-textdocument": "1.0.1",
-    "vscode-uri": "2.1.2",
-    "yaml": "1.10.2"
+    "vscode-uri": "2.1.2"
   },
   "devDependencies": {
     "@types/node-fetch": "2.5.10",

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -103,7 +103,6 @@ connection.onCompletion(
   async (
     textDocumentPosition: TextDocumentPositionParams
   ): Promise<CompletionItem[]> => {
-    // TODO if (semanticModelLoaded !== undefined) {
     getLogger().debug("`onCompletion` event", {
       textDocumentPosition,
     });
@@ -118,6 +117,10 @@ connection.onCompletion(
         "SAPUI5",
         minUI5Version
       );
+      connection.sendNotification(
+        "UI5LanguageAssistant/ui5Model",
+        model.version
+      );
       ensureDocumentSettingsUpdated(document.uri);
       const documentSettings = await getSettingsForDocument(document.uri);
       const completionItems = getCompletionItems({
@@ -129,7 +132,6 @@ connection.onCompletion(
       getLogger().trace("computed completion items", { completionItems });
       return completionItems;
     }
-    //}
     return [];
   }
 );
@@ -144,7 +146,6 @@ connection.onHover(
   async (
     textDocumentPosition: TextDocumentPositionParams
   ): Promise<Hover | undefined> => {
-    // TODO if (semanticModelLoaded !== undefined) {
     getLogger().debug("`onHover` event", {
       textDocumentPosition,
     });
@@ -158,6 +159,10 @@ connection.onHover(
         "SAPUI5",
         minUI5Version
       );
+      connection.sendNotification(
+        "UI5LanguageAssistant/ui5Model",
+        ui5Model.version
+      );
       const hoverResponse = getHoverResponse(
         ui5Model,
         textDocumentPosition,
@@ -168,7 +173,6 @@ connection.onHover(
       });
       return hoverResponse;
     }
-    //}
     return undefined;
   }
 );
@@ -204,6 +208,10 @@ documents.onDidChangeContent(async (changeEvent) => {
       "SAPUI5",
       minUI5Version
     );
+    connection.sendNotification(
+      "UI5LanguageAssistant/ui5Model",
+      ui5Model.version
+    );
     const diagnostics = getXMLViewDiagnostics({
       document,
       ui5Model,
@@ -229,6 +237,10 @@ connection.onCodeAction(async (params) => {
     initializationOptions?.modelCachePath,
     "SAPUI5",
     minUI5Version
+  );
+  connection.sendNotification(
+    "UI5LanguageAssistant/ui5Model",
+    ui5Model.version
   );
 
   const diagnostics = params.context.diagnostics;

--- a/packages/language-server/src/ui5-model.ts
+++ b/packages/language-server/src/ui5-model.ts
@@ -162,7 +162,9 @@ export async function getSemanticModelWithFetcher(
     strict: false,
     printValidationErrors: false,
   });
-  return (semanticModelCache[key] = model);
+  // cache the model
+  semanticModelCache[key] = model;
+  return model;
 }
 
 async function readFromCache(filePath: string | undefined): Promise<unknown> {

--- a/packages/language-server/test/completion-items-classes-spec.ts
+++ b/packages/language-server/test/completion-items-classes-spec.ts
@@ -22,7 +22,7 @@ describe("the UI5 language assistant Code Completion Services - classes", () => 
   let ui5SemanticModel: UI5SemanticModel;
   before(async function () {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/language-server/test/completion-items-literals-spec.ts
+++ b/packages/language-server/test/completion-items-literals-spec.ts
@@ -10,7 +10,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
   let ui5SemanticModel: UI5SemanticModel;
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/language-server/test/completion-items-spec.ts
+++ b/packages/language-server/test/completion-items-spec.ts
@@ -26,7 +26,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
   let ui5SemanticModel: UI5SemanticModel;
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/language-server/test/documentation-spec.ts
+++ b/packages/language-server/test/documentation-spec.ts
@@ -11,7 +11,7 @@ describe("The @ui5-language-assistant/language-server <getNodeDocumentation> fun
   let ui5SemanticModel: UI5SemanticModel;
   before(async function () {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/language-server/test/hover-spec.ts
+++ b/packages/language-server/test/hover-spec.ts
@@ -21,7 +21,7 @@ describe("the UI5 language assistant Hover Tooltip Service", () => {
   let ui5SemanticModel: UI5SemanticModel;
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/language-server/test/snapshots/xml-view-diagnostics/snapshots-utils.ts
+++ b/packages/language-server/test/snapshots/xml-view-diagnostics/snapshots-utils.ts
@@ -93,7 +93,7 @@ export function readSnapshotDiagnosticsLSPResponse(
 }
 
 const ui5ModelPromise = generateModel({
-  framework: "sapui5",
+  framework: "SAPUI5",
   version: "1.71.49",
   modelGenerator: generate,
 });

--- a/packages/language-server/test/ui5-model-spec.ts
+++ b/packages/language-server/test/ui5-model-spec.ts
@@ -16,7 +16,7 @@ import { forEach, isPlainObject } from "lodash";
 describe("the UI5 language assistant ui5 model", () => {
   // The default timeout is 2000ms and getSemanticModel can take ~3000-5000ms
   const GET_MODEL_TIMEOUT = 10000;
-  const FRAMEWORK = "sapui5";
+  const FRAMEWORK = "SAPUI5";
   const VERSION = "1.71.49";
   const NO_CACHE_FOLDER = undefined;
 
@@ -48,7 +48,12 @@ describe("the UI5 language assistant ui5 model", () => {
   }
 
   it("will get UI5 semantic model", async () => {
-    const ui5Model = await getSemanticModel(NO_CACHE_FOLDER, "");
+    const ui5Model = await getSemanticModel(
+      NO_CACHE_FOLDER,
+      undefined,
+      undefined,
+      true
+    );
     assertSemanticModel(ui5Model);
   }).timeout(GET_MODEL_TIMEOUT);
 
@@ -64,7 +69,9 @@ describe("the UI5 language assistant ui5 model", () => {
         };
       },
       NO_CACHE_FOLDER,
-      ""
+      undefined,
+      undefined,
+      true
     );
     expect(ui5Model).to.exist;
   });
@@ -83,7 +90,12 @@ describe("the UI5 language assistant ui5 model", () => {
       });
 
       it("caches the model the first time getSemanticModel is called", async () => {
-        const ui5Model = await getSemanticModel(cachePath, "");
+        const ui5Model = await getSemanticModel(
+          cachePath,
+          undefined,
+          undefined,
+          true
+        );
         assertSemanticModel(ui5Model);
 
         // Check the files were created in the folder
@@ -100,7 +112,9 @@ describe("the UI5 language assistant ui5 model", () => {
             );
           },
           cachePath,
-          ""
+          undefined,
+          undefined,
+          true
         );
         expect(fetcherCalled).to.be.false;
         // Make sure it's not the model itself that is cached
@@ -132,7 +146,11 @@ describe("the UI5 language assistant ui5 model", () => {
         expectExists(cacheFilePath, "cacheFilePath");
         await mkdirs(cacheFilePath);
 
-        const ui5Model = await getSemanticModel(cachePath, "");
+        const ui5Model = await getSemanticModel(
+          cachePath,
+          undefined,
+          undefined
+        );
         expect(ui5Model).to.exist;
         // Check we still got the sap.m library data
         expect(Object.keys(ui5Model.namespaces)).to.contain("sap.m");
@@ -147,7 +165,12 @@ describe("the UI5 language assistant ui5 model", () => {
         expectExists(cacheFilePath, "cacheFilePath");
         await writeFile(cacheFilePath, "not json");
 
-        const ui5Model = await getSemanticModel(cachePath, "");
+        const ui5Model = await getSemanticModel(
+          cachePath,
+          undefined,
+          undefined,
+          true
+        );
         expect(ui5Model).to.exist;
         // Check we still got the sap.m library data
         expect(Object.keys(ui5Model.namespaces)).to.contain("sap.m");
@@ -167,7 +190,12 @@ describe("the UI5 language assistant ui5 model", () => {
       });
 
       it("does not cache the model", async () => {
-        const ui5Model = await getSemanticModel(cachePath, "");
+        const ui5Model = await getSemanticModel(
+          cachePath,
+          undefined,
+          undefined,
+          true
+        );
         assertSemanticModel(ui5Model);
 
         // Call getSemanticModel again with the same path and check it doesn't try to read from the URL
@@ -184,7 +212,9 @@ describe("the UI5 language assistant ui5 model", () => {
             };
           },
           cachePath,
-          ""
+          undefined,
+          undefined,
+          true
         );
         expect(fetcherCalled).to.be.true;
       }).timeout(GET_MODEL_TIMEOUT);

--- a/packages/language-server/test/ui5-model-spec.ts
+++ b/packages/language-server/test/ui5-model-spec.ts
@@ -280,14 +280,11 @@ describe("the UI5 language assistant ui5 model", () => {
     it("resolve the default version", async () => {
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(true, 200, versionInfo);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionInfo);
           },
           cachePath,
           FRAMEWORK,
@@ -296,33 +293,30 @@ describe("the UI5 language assistant ui5 model", () => {
       ).to.be.equal(VERSION);
     });
 
-    it("resolve available concrete version", async () => {
+    it("resolve available concrete version (1.105.0)", async () => {
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(true, 200, versionInfo);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionInfo);
           },
           cachePath,
           FRAMEWORK,
           "1.105.0"
         )
       ).to.be.equal("1.105.0");
+    });
+
+    it("resolve available concrete version (1.104.0)", async () => {
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(true, 200, versionInfo);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionInfo);
           },
           cachePath,
           FRAMEWORK,
@@ -334,14 +328,11 @@ describe("the UI5 language assistant ui5 model", () => {
     it("resolve not available concrete version (should be latest)", async () => {
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,
@@ -353,14 +344,11 @@ describe("the UI5 language assistant ui5 model", () => {
     it("resolve major.minor versions (should be closest)", async () => {
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,
@@ -369,14 +357,11 @@ describe("the UI5 language assistant ui5 model", () => {
       ).to.be.equal("1.105.0");
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,
@@ -385,14 +370,11 @@ describe("the UI5 language assistant ui5 model", () => {
       ).to.be.equal("1.96.11");
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,
@@ -401,14 +383,11 @@ describe("the UI5 language assistant ui5 model", () => {
       ).to.be.equal("1.84.27");
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,
@@ -417,14 +396,11 @@ describe("the UI5 language assistant ui5 model", () => {
       ).to.be.equal("1.71.50");
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,
@@ -436,14 +412,11 @@ describe("the UI5 language assistant ui5 model", () => {
     it("resolve major version (should be closest)", async () => {
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,
@@ -452,17 +425,14 @@ describe("the UI5 language assistant ui5 model", () => {
       ).to.be.equal("1.71.50");
     });
 
-    it("resolve invalid versions (should be default)", async () => {
+    it("resolve invalid versions (should be latest)", async () => {
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,
@@ -471,14 +441,11 @@ describe("the UI5 language assistant ui5 model", () => {
       ).to.be.equal("1.71.49");
       expect(
         await negotiateVersionWithFetcher(
-          async (url: string): Promise<FetchResponse> => {
-            if (url.endsWith("/version.json")) {
-              // request for version mapping info
-              return createResponse(true, 200, versionMap);
-            } else {
-              // request for version info (needs to be just an object => found!)
-              return createResponse(false, 404);
-            }
+          async (): Promise<FetchResponse> => {
+            return createResponse(true, 200, versionMap);
+          },
+          async (): Promise<FetchResponse> => {
+            return createResponse(false, 404);
           },
           cachePath,
           FRAMEWORK,

--- a/packages/logic-utils/src/utils/documentation.ts
+++ b/packages/logic-utils/src/utils/documentation.ts
@@ -195,7 +195,7 @@ export function getLink(model: UI5SemanticModel, link: string): string {
     return link;
   }
   let baseUrl;
-  if (model.framework === "openui5") {
+  if (model.framework === "OPENUI5") {
     baseUrl = "https://sdk.openui5.org/";
   } else {
     baseUrl = "https://ui5.sap.com/";

--- a/packages/logic-utils/test/utils/documentation-spec.ts
+++ b/packages/logic-utils/test/utils/documentation-spec.ts
@@ -198,7 +198,7 @@ describe("The @ui5-language-assistant/logic-utils <convertJSDocToMarkdown> funct
 
   it("replaces link tags that point to UI5 classes with markdown links when model has a version (OpenUI5)", () => {
     const modelWithVersion = buildUI5Model({
-      framework: "openui5",
+      framework: "OPENUI5",
       version: "1.2.3",
     });
     expect(
@@ -212,7 +212,7 @@ describe("The @ui5-language-assistant/logic-utils <convertJSDocToMarkdown> funct
   });
 
   it("replaces link tags that point to UI5 classes with markdown links when model doesn't have a version (OpenUI5)", () => {
-    const modelOpenUI5 = buildUI5Model({ framework: "openui5" });
+    const modelOpenUI5 = buildUI5Model({ framework: "OPENUI5" });
     expect(
       convertJSDocToMarkdown(
         "This text has a {@link sap.m.Button link to Button} and a nameless link to a type: {@link sap.m.Button}",

--- a/packages/logic-utils/test/utils/find-classes-matching-spec.ts
+++ b/packages/logic-utils/test/utils/find-classes-matching-spec.ts
@@ -13,7 +13,7 @@ describe("The @ui5-language-assistant/logic-utils <findClassesMatchingType> func
   let ui5Model: UI5SemanticModel;
   before(async () => {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });
@@ -76,7 +76,7 @@ describe("The @ui5-language-assistant/logic-utils <classIsOfType> function", () 
   let ui5Model: UI5SemanticModel;
   before(async () => {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/logic-utils/test/utils/get-super-class-spec.ts
+++ b/packages/logic-utils/test/utils/get-super-class-spec.ts
@@ -36,7 +36,7 @@ describe("The @ui5-language-assistant/logic-utils <getSuperClasses> function", (
   it("will avoid infinite loops in case of cyclic extends clauses", async () => {
     const ui5Model = cloneDeep(
       await generateModel({
-        framework: "sapui5",
+        framework: "SAPUI5",
         version: "1.71.49",
         modelGenerator: generate,
       })

--- a/packages/logic-utils/test/utils/xml-node-to-ui5-node-spec.ts
+++ b/packages/logic-utils/test/utils/xml-node-to-ui5-node-spec.ts
@@ -22,7 +22,7 @@ describe("The @ui5-language-assistant/logic-utils <getUI5ClassByXMLElement> func
   let ui5Model: UI5SemanticModel;
   before(async () => {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });
@@ -105,7 +105,7 @@ describe("The @ui5-language-assistant/logic-utils <getUI5ClassByXMLElementClosin
   let ui5Model: UI5SemanticModel;
   before(async () => {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });
@@ -187,7 +187,7 @@ describe("The @ui5-language-assistant/logic-utils <getUI5AggregationByXMLElement
   let ui5Model: UI5SemanticModel;
   before(async () => {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });
@@ -337,7 +337,7 @@ describe("The @ui5-language-assistant/logic-utils <getUI5NodeByXMLAttribute> fun
   let ui5Model: UI5SemanticModel;
   before(async () => {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });
@@ -432,7 +432,7 @@ describe("The @ui5-language-assistant/logic-utils <getUI5PropertyByXMLAttributeK
   let ui5Model: UI5SemanticModel;
   before(async () => {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });
@@ -496,7 +496,7 @@ describe("The @ui5-language-assistant/logic-utils <getUI5NodeFromXMLElementNames
   let ui5Model: UI5SemanticModel;
   before(async () => {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/semantic-model-types/api.d.ts
+++ b/packages/semantic-model-types/api.d.ts
@@ -1,4 +1,4 @@
-export type UI5Framework = "openui5" | "sapui5";
+export type UI5Framework = "OPENUI5" | "SAPUI5";
 
 export interface UI5SemanticModel {
   version?: string;

--- a/packages/semantic-model/src/resolve.ts
+++ b/packages/semantic-model/src/resolve.ts
@@ -31,7 +31,7 @@ export function setParent(
       // Always throwing an error because we add these symbols implicitly so an error here means we have a bug
       error(
         `Symbol ${parentFqn} not found (should be parent of ${fqn}) [${
-          model.framework || "sapui5"
+          model.framework || "SAPUI5"
         }:${model.version}]`,
         true
       );
@@ -67,7 +67,7 @@ export function resolveSemanticProperties(
             `${jsonSymbol.extends} is a ${
               extendsType.kind
             } and not a class (class ${key} extends it) [${
-              model.framework || "sapui5"
+              model.framework || "SAPUI5"
             }:${model.version}]`,
             strict
           );
@@ -85,7 +85,7 @@ export function resolveSemanticProperties(
               `${interfacee} is a ${
                 interfaceType.kind
               } and not an interface (class ${key} implements it) [${
-                model.framework || "sapui5"
+                model.framework || "SAPUI5"
               }:${model.version}]`,
               strict
             );
@@ -107,7 +107,7 @@ export function resolveSemanticProperties(
       if (classs.defaultAggregation === undefined) {
         error(
           `Unknown default aggregation ${defaultAggregation} in class ${key} [${
-            model.framework || "sapui5"
+            model.framework || "SAPUI5"
           }:${model.version}]`,
           strict
         );
@@ -248,7 +248,7 @@ export function resolveType({
     };
   } else {
     error(
-      `Unknown type: ${typeName} [${model.framework || "sapui5"}:${
+      `Unknown type: ${typeName} [${model.framework || "SAPUI5"}:${
         model.version
       }]`,
       strict

--- a/packages/semantic-model/test/api-spec.ts
+++ b/packages/semantic-model/test/api-spec.ts
@@ -303,7 +303,7 @@ context("The ui5-language-assistant semantic model package API", () => {
   ];
   for (const version of versions) {
     // TODO: consider also openui5?
-    createModelConsistencyTests("sapui5", version);
+    createModelConsistencyTests("SAPUI5", version);
   }
 
   describe("returned model is frozen", () => {
@@ -313,7 +313,7 @@ context("The ui5-language-assistant semantic model package API", () => {
     let model: UI5SemanticModel;
     before(async () => {
       model = await generateModel({
-        framework: "sapui5",
+        framework: "SAPUI5",
         version: "1.71.49",
         modelGenerator: generate,
       });
@@ -370,7 +370,7 @@ context("The ui5-language-assistant semantic model package API", () => {
     let model: UI5SemanticModel;
     before(async () => {
       model = await generateModel({
-        framework: "sapui5",
+        framework: "SAPUI5",
         version: "1.71.49",
         modelGenerator: generate,
       });

--- a/packages/semantic-model/test/utils-spec.ts
+++ b/packages/semantic-model/test/utils-spec.ts
@@ -12,7 +12,7 @@ describe("The semantic model utils", () => {
 
   before(async () => {
     model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/vscode-ui5-language-assistant/src/constants.ts
+++ b/packages/vscode-ui5-language-assistant/src/constants.ts
@@ -1,1 +1,2 @@
+export const COMMAND_OPEN_DEMOKIT = "UI5LanguageAssistant.command.openDemokit";
 export const LOGGING_LEVEL_CONFIG_PROP = "UI5LanguageAssistant.logging.level";

--- a/packages/vscode-ui5-language-assistant/src/extension.ts
+++ b/packages/vscode-ui5-language-assistant/src/extension.ts
@@ -46,11 +46,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: "file", pattern: "**/*.{view,fragment}.xml" }],
     synchronize: {
-      fileEvents: [
-        workspace.createFileSystemWatcher("**/package.json"),
-        workspace.createFileSystemWatcher("**/ui5.yaml"),
-        workspace.createFileSystemWatcher("**/manifest.json"),
-      ],
+      fileEvents: [workspace.createFileSystemWatcher("**/manifest.json")],
     },
     outputChannelName: meta.displayName,
     initializationOptions: initializationOptions,

--- a/packages/xml-views-completion/test/api-spec.ts
+++ b/packages/xml-views-completion/test/api-spec.ts
@@ -18,7 +18,7 @@ describe("The `getXMLViewCompletions()` api", () => {
 
   before(async function () {
     REAL_UI5_MODEL = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-completion/test/providers/attributeName/namespace-spec.ts
+++ b/packages/xml-views-completion/test/providers/attributeName/namespace-spec.ts
@@ -149,7 +149,7 @@ describe("The ui5-language-assistant xml-views-completion", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-completion/test/providers/attributeName/prop-event-assoc-spec.ts
+++ b/packages/xml-views-completion/test/providers/attributeName/prop-event-assoc-spec.ts
@@ -61,7 +61,7 @@ describe("The ui5-language-assistant xml-views-completion", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-completion/test/providers/attributeValue/boolean-literal-spec.ts
+++ b/packages/xml-views-completion/test/providers/attributeValue/boolean-literal-spec.ts
@@ -15,7 +15,7 @@ describe("The ui5-language-assistant xml-views-completion", () => {
   let ui5SemanticModel: UI5SemanticModel;
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-completion/test/providers/attributeValue/enum-spec.ts
+++ b/packages/xml-views-completion/test/providers/attributeValue/enum-spec.ts
@@ -12,7 +12,7 @@ describe("The ui5-language-assistant xml-views-completion", () => {
   let ui5SemanticModel: UI5SemanticModel;
   before(async function () {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-completion/test/providers/attributeValue/namespace-spec.ts
+++ b/packages/xml-views-completion/test/providers/attributeValue/namespace-spec.ts
@@ -25,7 +25,7 @@ describe("The ui5-editor-tools xml-views-completion", () => {
   let ui5SemanticModel: UI5SemanticModel;
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-completion/test/providers/elementName/aggregation-spec.ts
+++ b/packages/xml-views-completion/test/providers/elementName/aggregation-spec.ts
@@ -15,7 +15,7 @@ describe("The ui5-language-assistant xml-views-completion", () => {
   let REAL_UI5_MODEL: UI5SemanticModel;
   before(async () => {
     REAL_UI5_MODEL = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-completion/test/providers/elementName/classes-spec.ts
+++ b/packages/xml-views-completion/test/providers/elementName/classes-spec.ts
@@ -23,7 +23,7 @@ describe("The ui5-language-assistant xml-views-completion", () => {
   let ui5Model: UI5SemanticModel;
   before(async function () {
     ui5Model = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-tooltip/test/tooltip-spec.ts
+++ b/packages/xml-views-tooltip/test/tooltip-spec.ts
@@ -18,7 +18,7 @@ describe("the UI5 language assistant Hover Tooltip Service", () => {
   let ui5SemanticModel: UI5SemanticModel;
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/api-spec.ts
+++ b/packages/xml-views-validation/test/api-spec.ts
@@ -14,7 +14,7 @@ describe("the ui5 xml views validations API", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/attributes/invalid-boolean-value-spec.ts
+++ b/packages/xml-views-validation/test/validators/attributes/invalid-boolean-value-spec.ts
@@ -13,7 +13,7 @@ describe("the invalid boolean value validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/attributes/unknown-attribute-key-spec.ts
+++ b/packages/xml-views-validation/test/validators/attributes/unknown-attribute-key-spec.ts
@@ -19,7 +19,7 @@ describe("the unknown attribute name validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/attributes/unknown-enum-value-spec.ts
+++ b/packages/xml-views-validation/test/validators/attributes/unknown-enum-value-spec.ts
@@ -13,7 +13,7 @@ describe("the unknown enum value validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/attributes/unknown-xmlns-namespace-spec.ts
+++ b/packages/xml-views-validation/test/validators/attributes/unknown-xmlns-namespace-spec.ts
@@ -13,7 +13,7 @@ describe("the unknown namespace in xmlns attribute value validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/attributes/use-of-depracated-attribute-spec.ts
+++ b/packages/xml-views-validation/test/validators/attributes/use-of-depracated-attribute-spec.ts
@@ -23,7 +23,7 @@ describe("the use of deprecated attribute validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/document/non-unique-id-spec.ts
+++ b/packages/xml-views-validation/test/validators/document/non-unique-id-spec.ts
@@ -25,7 +25,7 @@ describe("the use of non unique id validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/element/cardinality-of-aggregation-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/cardinality-of-aggregation-spec.ts
@@ -19,7 +19,7 @@ describe("the cardinality aggregation validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/element/non-stable-id-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/non-stable-id-spec.ts
@@ -19,7 +19,7 @@ describe("the use of non stable id validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/element/type-of-aggregation-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/type-of-aggregation-spec.ts
@@ -23,7 +23,7 @@ describe("the type aggregation validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/element/unknown-tag-name-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/unknown-tag-name-spec.ts
@@ -31,7 +31,7 @@ describe("the unknown tag name validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/element/use-of-deprecated-aggregation-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/use-of-deprecated-aggregation-spec.ts
@@ -17,7 +17,7 @@ describe("the use of deprecated aggregation validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/packages/xml-views-validation/test/validators/element/use-of-deprecated-class-spec.ts
+++ b/packages/xml-views-validation/test/validators/element/use-of-deprecated-class-spec.ts
@@ -13,7 +13,7 @@ describe("the use of deprecated class validation", () => {
 
   before(async () => {
     ui5SemanticModel = await generateModel({
-      framework: "sapui5",
+      framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7659,6 +7659,13 @@ semver@^7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
@@ -9170,11 +9177,6 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
-yaml@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/semver@7.3.12":
+  version "7.3.12"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.12.tgz#920447fdd78d76b19de0438b7f60df3c4a80bf1c"
+  integrity sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==
+
 "@types/sinon-chai@3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-3.2.5.tgz#df21ae57b10757da0b26f512145c065f2ad45c48"
@@ -7647,6 +7652,13 @@ semver@7.3.2, semver@^7.2.1, semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+semver@7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
@@ -7656,13 +7668,6 @@ semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.3.7:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
To support mono-repos having different UI5 projects and to ensure that
the correct minUI5Version of the UI5 application/library is being used
the UI5 version will now be derived from the closest manifest.json of
the XMLView to be edited.

`manifest.json`:

```json
{
  [...]
  "sap.ui5": {
    "dependencies": {
      "minUI5Version": "${anySemVer}"
    }
  }
  [...]
}
```

The detection of the used framework has been removed so far and would
require an additional metadata in some UI5 application/library related
metadata. This can be re-added for future versions.