### PR TITLE
build(deploy-ghr): use specific go script ghr@v0.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
-            go get github.com/tcnksm/ghr
+            go get github.com/tcnksm/ghr@v0.14.0
             VERSION=${CIRCLE_TAG}
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./dist/
 


### PR DESCRIPTION
The latest version https://github.com/tcnksm/ghr@v0.15.0 fails.
Therefore we rollback to https://github.com/tcnksm/ghr@v0.14.0.