### PR TITLE
fix: duplicate code completion items

### DIFF
--- a/packages/logic-utils/src/utils/flatten-members.ts
+++ b/packages/logic-utils/src/utils/flatten-members.ts
@@ -1,4 +1,4 @@
-import { partial } from "lodash";
+import { partial, filter, concat } from "lodash";
 import { UI5Class } from "@ui5-language-assistant/semantic-model-types";
 
 function flattenMembers<T extends { name: string }>(
@@ -10,13 +10,13 @@ function flattenMembers<T extends { name: string }>(
   if (ui5SuperClass !== undefined) {
     // UI5 SDK refers to inherited members (properties, events, aggregations. ...) as "borrowed" ...
     const borrowedMembers = flattenMembers(membersGetter, ui5SuperClass);
-    return directMembers.concat(
-      borrowedMembers.filter(
-        (borrowed) =>
-          directMembers.find((direct) => direct.name === borrowed.name) ===
-          undefined
-      )
+    const borrowedMembersWithoutOverrides = filter(
+      borrowedMembers,
+      (borrowed) =>
+        directMembers.find((direct) => direct.name === borrowed.name) ===
+        undefined
     );
+    return concat(directMembers, borrowedMembersWithoutOverrides);
   }
   return directMembers;
 }

--- a/packages/logic-utils/src/utils/flatten-members.ts
+++ b/packages/logic-utils/src/utils/flatten-members.ts
@@ -1,4 +1,4 @@
-import { partial, filter, concat } from "lodash";
+import { partial, filter, concat, find } from "lodash";
 import { UI5Class } from "@ui5-language-assistant/semantic-model-types";
 
 function flattenMembers<T extends { name: string }>(
@@ -13,7 +13,7 @@ function flattenMembers<T extends { name: string }>(
     const borrowedMembersWithoutOverrides = filter(
       borrowedMembers,
       (borrowed) =>
-        directMembers.find((direct) => direct.name === borrowed.name) ===
+        find(directMembers, (direct) => direct.name === borrowed.name) ===
         undefined
     );
     return concat(directMembers, borrowedMembersWithoutOverrides);

--- a/packages/logic-utils/src/utils/flatten-members.ts
+++ b/packages/logic-utils/src/utils/flatten-members.ts
@@ -1,7 +1,7 @@
 import { partial } from "lodash";
 import { UI5Class } from "@ui5-language-assistant/semantic-model-types";
 
-function flattenMembers<T>(
+function flattenMembers<T extends { name: string }>(
   membersGetter: (ui5Class: UI5Class) => T[],
   ui5Class: UI5Class
 ): T[] {
@@ -10,7 +10,13 @@ function flattenMembers<T>(
   if (ui5SuperClass !== undefined) {
     // UI5 SDK refers to inherited members (properties, events, aggregations. ...) as "borrowed" ...
     const borrowedMembers = flattenMembers(membersGetter, ui5SuperClass);
-    return directMembers.concat(borrowedMembers);
+    return directMembers.concat(
+      borrowedMembers.filter(
+        (borrowed) =>
+          directMembers.find((direct) => direct.name === borrowed.name) ===
+          undefined
+      )
+    );
   }
   return directMembers;
 }

--- a/packages/logic-utils/test/utils/flatten-property-spec.ts
+++ b/packages/logic-utils/test/utils/flatten-property-spec.ts
@@ -24,6 +24,12 @@ describe("The @ui5-language-assistant/logic-utils <flattenAggregations> function
   });
 
   const clazzC = buildUI5Class({ name: "C", extends: clazzA });
+  const propA1Override = buildUI5Property({ name: "propA1" });
+  const classD = buildUI5Class({
+    name: "D",
+    extends: clazzA,
+    properties: [propA1Override, propB1, propB2],
+  });
 
   it("direct properties", () => {
     const actualNames = map(flattenProperties(clazzA), "name");
@@ -37,6 +43,16 @@ describe("The @ui5-language-assistant/logic-utils <flattenAggregations> function
 
   it("direct and borrowed properties", () => {
     const actualNames = map(flattenProperties(clazzB), "name");
+    expectUnsortedEquality(actualNames, [
+      "propA1",
+      "propA2",
+      "propB1",
+      "propB2",
+    ]);
+  });
+
+  it("direct and borrowed properties with overrides", () => {
+    const actualNames = map(flattenProperties(classD), "name");
     expectUnsortedEquality(actualNames, [
       "propA1",
       "propA2",


### PR DESCRIPTION
Controls that override the inherited properties had duplicate completion items for attribute names e.g. https://ui5.sap.com/1.102.0/#/api/sap.fe.macros.FilterBar.

Changed `flattenMembers` function to return only unique members (by name).