### PR TITLE
chore: introduce app context

### DIFF
--- a/packages/language-server/src/cache.ts
+++ b/packages/language-server/src/cache.ts
@@ -17,10 +17,10 @@ class ProjectCache {
   }
 
   /**
-   * Get all cached manifest details
+   * Get entries of cached manifest details
    */
-  getAllManifestDetails(): Map<AbsolutePathToManifest, ManifestDetails> {
-    return this._manifestDetails;
+  getManifestDetailsEntries(): string[] {
+    return [...this._manifestDetails.keys()];
   }
   getManifestDetails(documentPath: string): ManifestDetails | undefined {
     return this._manifestDetails.get(documentPath);
@@ -32,10 +32,10 @@ class ProjectCache {
     return this._manifestDetails.delete(documentPath);
   }
   /**
-   * Get all cached yaml details
+   * Get entries of cached yaml details
    */
-  getAllYamlDetails(): Map<AbsolutePathToYaml, YamlDetails> {
-    return this._ui5YamlDetails;
+  getYamlDetailsEntries(): string[] {
+    return [...this._ui5YamlDetails.keys()];
   }
   getYamlDetails(documentPath: string): YamlDetails | undefined {
     return this._ui5YamlDetails.get(documentPath);
@@ -47,10 +47,10 @@ class ProjectCache {
     return this._ui5YamlDetails.delete(documentPath);
   }
   /**
-   * Get all cached UI5 model
+   * Get entries of cached UI5 model
    */
-  getAllUI5Model(): Map<AbsolutePathToManifest, UI5SemanticModel> {
-    return this._ui5Model;
+  getUI5ModelEntries(): string[] {
+    return [...this._ui5Model.keys()];
   }
   getUI5Model(key: string): UI5SemanticModel | undefined {
     return this._ui5Model.get(key);

--- a/packages/language-server/src/cache.ts
+++ b/packages/language-server/src/cache.ts
@@ -1,0 +1,70 @@
+import {
+  ManifestDetails,
+  UI5SemanticModel,
+  YamlDetails,
+} from "@ui5-language-assistant/semantic-model-types";
+
+type AbsolutePathToManifest = string;
+type AbsolutePathToYaml = string;
+class ProjectCache {
+  private _manifestDetails: Map<AbsolutePathToManifest, ManifestDetails>;
+  private _ui5YamlDetails: Map<AbsolutePathToYaml, YamlDetails>;
+  private _ui5Model: Map<string, UI5SemanticModel>;
+  constructor() {
+    this._manifestDetails = new Map();
+    this._ui5YamlDetails = new Map();
+    this._ui5Model = new Map();
+  }
+
+  /**
+   * Get all cached manifest details
+   */
+  getAllManifestDetails(): Map<AbsolutePathToManifest, ManifestDetails> {
+    return this._manifestDetails;
+  }
+  getManifestDetails(documentPath: string): ManifestDetails | undefined {
+    return this._manifestDetails.get(documentPath);
+  }
+  setManifestDetails(documentPath: string, data: ManifestDetails): void {
+    this._manifestDetails.set(documentPath, data);
+  }
+  deleteManifestDetails(documentPath: string): boolean {
+    return this._manifestDetails.delete(documentPath);
+  }
+  /**
+   * Get all cached yaml details
+   */
+  getAllYamlDetails(): Map<AbsolutePathToYaml, YamlDetails> {
+    return this._ui5YamlDetails;
+  }
+  getYamlDetails(documentPath: string): YamlDetails | undefined {
+    return this._ui5YamlDetails.get(documentPath);
+  }
+  setYamlDetails(documentPath: string, data: YamlDetails): void {
+    this._ui5YamlDetails.set(documentPath, data);
+  }
+  deleteYamlDetails(documentPath: string): boolean {
+    return this._ui5YamlDetails.delete(documentPath);
+  }
+  /**
+   * Get all cached UI5 model
+   */
+  getAllUI5Model(): Map<AbsolutePathToManifest, UI5SemanticModel> {
+    return this._ui5Model;
+  }
+  getUI5Model(key: string): UI5SemanticModel | undefined {
+    return this._ui5Model.get(key);
+  }
+  setUI5Model(key: string, data: UI5SemanticModel): void {
+    this._ui5Model.set(key, data);
+  }
+  deleteUI5Model(key: string): boolean {
+    return this._ui5Model.delete(key);
+  }
+}
+
+/**
+ * Create singleton instance of ProjectCache
+ */
+const cache = new ProjectCache();
+export { cache };

--- a/packages/language-server/src/completion-items.ts
+++ b/packages/language-server/src/completion-items.ts
@@ -18,7 +18,10 @@ import {
   XMLElement,
   XMLDocument,
 } from "@xml-tools/ast";
-import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
+import {
+  AppContext,
+  UI5SemanticModel,
+} from "@ui5-language-assistant/semantic-model-types";
 import {
   getXMLViewCompletions,
   UI5XMLViewCompletion,
@@ -31,7 +34,7 @@ import { Settings } from "@ui5-language-assistant/settings";
 import { assertNever } from "assert-never";
 
 export function getCompletionItems(opts: {
-  model: UI5SemanticModel;
+  context: AppContext;
   textDocumentPosition: TextDocumentPositionParams;
   document: TextDocument;
   documentSettings: Settings;
@@ -40,7 +43,7 @@ export function getCompletionItems(opts: {
   const { cst, tokenVector } = parse(documentText);
   const ast = buildAst(cst as DocumentCstNode, tokenVector);
   const suggestions = getXMLViewCompletions({
-    model: opts.model,
+    model: opts.context.ui5Model,
     offset: opts.document.offsetAt(opts.textDocumentPosition.position),
     cst: cst as DocumentCstNode,
     ast: ast,
@@ -50,7 +53,7 @@ export function getCompletionItems(opts: {
 
   const completionItems = transformToLspSuggestions(
     suggestions,
-    opts.model,
+    opts.context.ui5Model,
     opts.textDocumentPosition
   );
   return completionItems;

--- a/packages/language-server/src/context.ts
+++ b/packages/language-server/src/context.ts
@@ -1,0 +1,35 @@
+import type {
+  AppContext,
+  UI5SemanticModel,
+} from "@ui5-language-assistant/semantic-model-types";
+import { cache } from "./cache";
+import { getMinUI5VersionForXMLFile } from "./manifest-handling";
+import { getManifestPath } from "./path";
+import { getSemanticModel } from "./ui5-model";
+import { getUI5FrameworkForXMLFile } from "./ui5yaml-handling";
+
+export const getUI5Model = async (
+  documentPath: string,
+  modelCachePath?: string
+): Promise<UI5SemanticModel> => {
+  const minUI5Version = getMinUI5VersionForXMLFile(documentPath);
+  const framework = getUI5FrameworkForXMLFile(documentPath);
+  const model = await getSemanticModel(
+    modelCachePath,
+    framework,
+    minUI5Version
+  );
+  return model;
+};
+
+export async function getContextForFile(
+  documentPath: string,
+  modelCachePath?: string
+): Promise<AppContext> {
+  const ui5Model = await getUI5Model(documentPath, modelCachePath);
+  const context: AppContext = {
+    ui5Model,
+    manifest: cache.getManifestDetails(getManifestPath(documentPath)),
+  };
+  return context;
+}

--- a/packages/language-server/src/manifest-handling.ts
+++ b/packages/language-server/src/manifest-handling.ts
@@ -35,7 +35,7 @@ export async function initializeManifestData(
 
 export function getFlexEnabledFlagForXMLFile(xmlPath: string): boolean {
   const manifestFilesForCurrentFolder = filter(
-    Array.from(cache.getAllManifestDetails().keys()),
+    cache.getManifestDetailsEntries(),
     (manifestPath) => xmlPath.startsWith(dirname(manifestPath))
   );
 
@@ -55,7 +55,7 @@ export function getMinUI5VersionForXMLFile(
   xmlPath: string
 ): string | undefined {
   const manifestFilesForCurrentFolder = filter(
-    Array.from(cache.getAllManifestDetails().keys()),
+    cache.getManifestDetailsEntries(),
     (manifestPath) => xmlPath.startsWith(dirname(manifestPath))
   );
 

--- a/packages/language-server/src/path.ts
+++ b/packages/language-server/src/path.ts
@@ -1,0 +1,17 @@
+import { join } from "path";
+import { DirName, FileName } from "./types";
+
+/**
+ * Returns the path of the corresponding manifest.json file for a given file path
+ *
+ * @param documentPath  Path of a document file in current project (i.e. c:/Users/someUser/project/webapp/ext/main/Main.view.xml)
+ * @returns         Path to manifest (i.e. c:/Users/someUser/project/webapp/manifest.json)
+ * @note it relays on the fact that `webapp` exits in path. If `webapp` does not exit, webapp/manifest.json is returned as a result
+ */
+
+export const getManifestPath = (documentPath: string): string => {
+  const pathSegments = documentPath.split(DirName.Webapp);
+  pathSegments.pop();
+  const manifestPath = join(...pathSegments, DirName.Webapp, FileName.Manifest);
+  return manifestPath;
+};

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -1,0 +1,15 @@
+export enum DirName {
+  Webapp = "webapp",
+  Controller = "controller",
+  View = "view",
+  Fragment = "fragment",
+  Ext = "ext",
+}
+
+export enum FileName {
+  Manifest = "manifest.json",
+  Package = "package.json",
+  Ui5Yaml = "ui5.yaml",
+  Ui5LocalYaml = "ui5-local.yaml",
+  Ui5MockYaml = "ui5-mock.yaml",
+}

--- a/packages/language-server/src/ui5-model.ts
+++ b/packages/language-server/src/ui5-model.ts
@@ -22,6 +22,7 @@ import {
   getVersionInfoUrl,
   getVersionJsonUrl,
 } from "./ui5-helper";
+import { cache } from "./cache";
 
 export async function getSemanticModel(
   modelCachePath: string | undefined,
@@ -38,11 +39,6 @@ export async function getSemanticModel(
   );
 }
 
-// cache the semantic model creation promise to ensure unique instances per version
-const semanticModelCache: Record<
-  string,
-  Promise<UI5SemanticModel>
-> = Object.create(null);
 // This function is exported for testing purposes (using a mock fetcher)
 export async function getSemanticModelWithFetcher(
   fetcher: Fetcher,
@@ -52,15 +48,16 @@ export async function getSemanticModelWithFetcher(
   ignoreCache?: boolean
 ): Promise<UI5SemanticModel> {
   const cacheKey = `${framework || "INVALID"}:${version || "INVALID"}`;
-  if (ignoreCache || semanticModelCache[cacheKey] === undefined) {
-    semanticModelCache[cacheKey] = createSemanticModelWithFetcher(
+  if (ignoreCache || cache.getUI5Model(cacheKey) === undefined) {
+    const data = await createSemanticModelWithFetcher(
       fetcher,
       modelCachePath,
       framework,
       version
     );
+    cache.setUI5Model(cacheKey, data);
   }
-  return semanticModelCache[cacheKey];
+  return cache.getUI5Model(cacheKey) as UI5SemanticModel;
 }
 
 // This function is exported for testing purposes (using a mock fetcher)

--- a/packages/language-server/test/cache-spec.ts
+++ b/packages/language-server/test/cache-spec.ts
@@ -1,0 +1,14 @@
+import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
+import { expect } from "chai";
+import { cache } from "../src/cache";
+
+describe("cache", () => {
+  it("show singleton instance", async () => {
+    cache.setUI5Model("key01", ({} as unknown) as UI5SemanticModel);
+    // importing again - no new instance is generated
+    const cacheModule = await import("../src/cache");
+    expect(cache.getAllUI5Model()).to.deep.equal(
+      cacheModule.cache.getAllUI5Model()
+    );
+  });
+});

--- a/packages/language-server/test/cache-spec.ts
+++ b/packages/language-server/test/cache-spec.ts
@@ -7,8 +7,8 @@ describe("cache", () => {
     cache.setUI5Model("key01", ({} as unknown) as UI5SemanticModel);
     // importing again - no new instance is generated
     const cacheModule = await import("../src/cache");
-    expect(cache.getAllUI5Model()).to.deep.equal(
-      cacheModule.cache.getAllUI5Model()
+    expect(cache.getUI5ModelEntries()).to.deep.equal(
+      cacheModule.cache.getUI5ModelEntries()
     );
   });
 });

--- a/packages/language-server/test/completion-items-classes-spec.ts
+++ b/packages/language-server/test/completion-items-classes-spec.ts
@@ -5,10 +5,10 @@ import {
   TextEdit,
   CompletionItem,
 } from "vscode-languageserver";
-import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
+import { AppContext } from "@ui5-language-assistant/semantic-model-types";
 import {
-  generateModel,
   expectExists,
+  getContextForFile,
 } from "@ui5-language-assistant/test-utils";
 import { generate } from "@ui5-language-assistant/semantic-model";
 import {
@@ -19,9 +19,9 @@ import {
 } from "./completion-items-utils";
 
 describe("the UI5 language assistant Code Completion Services - classes", () => {
-  let ui5SemanticModel: UI5SemanticModel;
+  let appContext: AppContext;
   before(async function () {
-    ui5SemanticModel = await generateModel({
+    appContext = await getContextForFile({
       framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
@@ -44,7 +44,7 @@ describe("the UI5 language assistant Code Completion Services - classes", () => 
     compareAttributes?: boolean;
   }): CompletionItem[] {
     const compareAttributes = opts.compareAttributes ?? true;
-    const suggestions = getSuggestions(opts.xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(opts.xmlSnippet, appContext);
     const ranges = getRanges(opts.xmlSnippet);
 
     const suggestionsDetails = map(suggestions, (suggestion) => ({
@@ -331,7 +331,7 @@ describe("the UI5 language assistant Code Completion Services - classes", () => 
 
   it("will return valid class suggestions for empty tag with no closing bracket", () => {
     const xmlSnippet = `<⇶`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     expect(suggestions).to.not.be.empty;
     forEach(suggestions, (suggestion) => {
       // We're not replacing any text, just adding
@@ -361,7 +361,7 @@ describe("the UI5 language assistant Code Completion Services - classes", () => 
 
   it("will return valid class suggestions for empty tag with closing bracket", () => {
     const xmlSnippet = `<⇶>`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     expect(suggestions).to.not.be.empty;
     forEach(suggestions, (suggestion) => {
       // We're not replacing any text, just adding

--- a/packages/language-server/test/completion-items-literals-spec.ts
+++ b/packages/language-server/test/completion-items-literals-spec.ts
@@ -1,15 +1,15 @@
 import { expect } from "chai";
 import { map, uniq } from "lodash";
 import { CompletionItemKind, TextEdit } from "vscode-languageserver";
-import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
-import { generateModel } from "@ui5-language-assistant/test-utils";
+import { AppContext } from "@ui5-language-assistant/semantic-model-types";
+import { getContextForFile } from "@ui5-language-assistant/test-utils";
 import { generate } from "@ui5-language-assistant/semantic-model";
 import { getSuggestions, getTextInRange } from "./completion-items-utils";
 
 describe("the UI5 language assistant Code Completion Services", () => {
-  let ui5SemanticModel: UI5SemanticModel;
+  let appContext: AppContext;
   before(async () => {
-    ui5SemanticModel = await generateModel({
+    appContext = await getContextForFile({
       framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
@@ -21,7 +21,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"
                           busy="⇶">`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -47,7 +47,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"
                           busy="t⇶a">`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(

--- a/packages/language-server/test/completion-items-spec.ts
+++ b/packages/language-server/test/completion-items-spec.ts
@@ -2,9 +2,9 @@ import { expect } from "chai";
 import { map, uniq, forEach } from "lodash";
 import { CompletionItemKind, TextEdit } from "vscode-languageserver";
 import { UI5XMLViewCompletion } from "@ui5-language-assistant/xml-views-completion";
-import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
+import { AppContext } from "@ui5-language-assistant/semantic-model-types";
 import { Settings } from "@ui5-language-assistant/settings";
-import { generateModel } from "@ui5-language-assistant/test-utils";
+import { getContextForFile } from "@ui5-language-assistant/test-utils";
 import { generate } from "@ui5-language-assistant/semantic-model";
 import { computeLSPKind } from "../src/completion-items";
 import {
@@ -23,9 +23,9 @@ describe("the UI5 language assistant Code Completion Services", () => {
     return `\${0:${text}}`;
   }
 
-  let ui5SemanticModel: UI5SemanticModel;
+  let appContext: AppContext;
   before(async () => {
-    ui5SemanticModel = await generateModel({
+    appContext = await getContextForFile({
       framework: "SAPUI5",
       version: "1.71.49",
       modelGenerator: generate,
@@ -37,7 +37,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List show⇶`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -63,7 +63,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List show⇶Separ`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -102,7 +102,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List show⇶Separ="true"`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -133,7 +133,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List update⇶`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -167,7 +167,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List update⇶Start="onUpdateStart"`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -201,7 +201,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List aria⇶`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -228,7 +228,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List aria⇶bbbb`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -255,7 +255,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List> <te⇶`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       tagName: getTagName(suggestion.textEdit as TextEdit),
@@ -282,7 +282,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns:m="sap.m"> 
                           <m:List> <te⇶`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       tagName: getTagName(suggestion.textEdit as TextEdit),
@@ -309,7 +309,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List> <te⇶Menu`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -340,7 +340,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns:m="sap.m"> 
                           <m:List> <te⇶Menu`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -378,7 +378,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
         <te⇶></⭲te⭰>
       </List>
     </mvc:View>`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       tagName: getTagName(suggestion.textEdit as TextEdit),
@@ -442,7 +442,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
         <m:te⇶></⭲m:te⭰>
       </m:List>
     </mvc:View>`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       tagName: getTagName(suggestion.textEdit as TextEdit),
@@ -506,7 +506,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
         <te⇶></aaa>
       </List>
     </mvc:View>`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       tagName: getTagName(suggestion.textEdit as TextEdit),
@@ -555,7 +555,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
         <te⇶>⭲</>⭰
       </List>
     </mvc:View>`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       tagName: getTagName(suggestion.textEdit as TextEdit),
@@ -615,7 +615,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     const xmlSnippet = `<mvc:View 
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns:u⇶`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -684,7 +684,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     const xmlSnippet = `<mvc:View 
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns:ux⇶a`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -717,7 +717,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     const xmlSnippet = `<mvc:View 
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns:ux⇶a="sap.m"`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -742,7 +742,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     const xmlSnippet = `<mvc:View 
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns:ux3="⇶"`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -760,7 +760,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     const xmlSnippet = `<mvc:View 
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="ux⇶a"`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -779,7 +779,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     const xmlSnippet = `<mvc:View 
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns:uxap="sap.u⇶i"`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -798,7 +798,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List showSeparators="⇶"`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -825,7 +825,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List showSeparators="n⇶ner"`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionsDetails = map(suggestions, (suggestion) => ({
       label: suggestion.label,
       replacedText: getTextInRange(
@@ -851,7 +851,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
                           xmlns:mvc="sap.ui.core.mvc" 
                           xmlns="sap.m"> 
                           <List ⇶`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     const suggestionKinds = uniq(
       map(suggestions, (suggestion) => suggestion.kind)
     );
@@ -874,7 +874,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
     const xmlSnippet = `<mvc:View xmlns:mvc="sap.ui.core.mvc">
       <⇶
     </mvc:View>`;
-    const suggestions = getSuggestions(xmlSnippet, ui5SemanticModel);
+    const suggestions = getSuggestions(xmlSnippet, appContext);
     expect(suggestions).to.not.be.empty;
     forEach(suggestions, (suggestion) => {
       // We're not replacing any text, just adding
@@ -930,7 +930,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
       // Check that it's returned when settings allow experimental
       const suggestionsAllAllowed = getSuggestions(
         xmlSnippet,
-        ui5SemanticModel,
+        appContext,
         ALLOW_ALL_SUGGESTIONS
       );
       const suggestionNamesWithAllAllowed = map(
@@ -944,7 +944,7 @@ describe("the UI5 language assistant Code Completion Services", () => {
       // Check that it's not returned when settings don't allow experimental
       const suggestionsWithSentSettings = getSuggestions(
         xmlSnippet,
-        ui5SemanticModel,
+        appContext,
         settings
       );
       const suggestionNamesWithSentSettings = map(

--- a/packages/language-server/test/completion-items-utils.ts
+++ b/packages/language-server/test/completion-items-utils.ts
@@ -9,7 +9,7 @@ import {
   TextEdit,
   Range,
 } from "vscode-languageserver";
-import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
+import { AppContext } from "@ui5-language-assistant/semantic-model-types";
 import { expectExists } from "@ui5-language-assistant/test-utils";
 import { getCompletionItems } from "../src/completion-items";
 import { Settings, getDefaultSettings } from "@ui5-language-assistant/settings";
@@ -26,7 +26,7 @@ export function getTagName(textEdit: TextEdit | undefined): string | undefined {
 /** Use ⇶ to mark the cursor position */
 export function getSuggestions(
   xmlSnippet: string,
-  ui5SemanticModel: UI5SemanticModel,
+  context: AppContext,
   settings?: Partial<Settings>
 ): CompletionItem[] {
   const { document, position } = getXmlSnippetDocument(xmlSnippet);
@@ -46,7 +46,7 @@ export function getSuggestions(
   ) as Settings;
 
   const suggestions = getCompletionItems({
-    model: ui5SemanticModel,
+    context,
     textDocumentPosition: textDocPositionParams,
     document,
     documentSettings: allSettings,

--- a/packages/language-server/test/context-spec.ts
+++ b/packages/language-server/test/context-spec.ts
@@ -1,0 +1,20 @@
+import { UI5SemanticModel } from "@ui5-language-assistant/semantic-model-types";
+import { expect } from "chai";
+import { restore, stub } from "sinon";
+import * as appContext from "../src/context";
+
+describe("context", () => {
+  afterEach(() => {
+    restore();
+  });
+  it("getContextForFile", async () => {
+    stub(appContext, "getUI5Model").resolves(
+      ("stubUi5Model" as unknown) as UI5SemanticModel
+    );
+    const result = await appContext.getContextForFile("a/b/c");
+    expect(result).to.deep.equal({
+      manifest: undefined,
+      ui5Model: "stubUi5Model",
+    });
+  });
+});

--- a/packages/language-server/test/path-spec.ts
+++ b/packages/language-server/test/path-spec.ts
@@ -1,0 +1,20 @@
+import { expect } from "chai";
+import { join } from "path";
+import { getManifestPath } from "../src/path";
+
+describe("path", () => {
+  context("getManifestPath", () => {
+    it("will get path to manifest json file where there is a webapp folder", () => {
+      const docPath = "c:/Users/someUser/project/webapp/ext/main/Main.view.xml";
+      const result = getManifestPath(docPath);
+      expect(result).to.equal(
+        join("c:", "Users", "someUser", "project", "webapp", "manifest.json")
+      );
+    });
+    it("will get 'webapp/manifest.json' as path because there is no webapp folder", () => {
+      const docPath = "ext/main/Main.view.xml";
+      const result = getManifestPath(docPath);
+      expect(result).to.equal(join("webapp", "manifest.json"));
+    });
+  });
+});

--- a/packages/semantic-model-types/api.d.ts
+++ b/packages/semantic-model-types/api.d.ts
@@ -10,7 +10,7 @@ export type ManifestDetails = {
   minUI5Version: string | undefined;
 };
 export type YamlDetails = {
-  flexEnabled: boolean;
+  framework: UI5Framework;
   version: string;
 };
 

--- a/packages/semantic-model-types/api.d.ts
+++ b/packages/semantic-model-types/api.d.ts
@@ -1,5 +1,19 @@
 export type UI5Framework = "OpenUI5" | "SAPUI5";
 
+export interface AppContext {
+  manifest?: ManifestDetails;
+  ui5Model: UI5SemanticModel;
+}
+
+export type ManifestDetails = {
+  flexEnabled: boolean;
+  minUI5Version: string | undefined;
+};
+export type YamlDetails = {
+  flexEnabled: boolean;
+  version: string;
+};
+
 export interface UI5SemanticModel {
   version?: string;
   framework?: UI5Framework;

--- a/test-packages/test-utils/api.d.ts
+++ b/test-packages/test-utils/api.d.ts
@@ -16,6 +16,7 @@ import {
   UI5EnumValue,
   UI5DeprecatedInfo,
   UI5Framework,
+  AppContext,
 } from "@ui5-language-assistant/semantic-model-types";
 import { XMLAttribute, XMLElement } from "@xml-tools/ast";
 import { UI5XMLViewCompletion } from "@ui5-language-assistant/xml-views-completion";
@@ -168,3 +169,11 @@ export type generateFunc = (opts: {
   strict: boolean;
   printValidationErrors?: boolean;
 }) => UI5SemanticModel;
+
+export function getContextForFile(opts: {
+  framework: UI5Framework;
+  version: TestModelVersion;
+  downloadLibs?: boolean;
+  strict?: boolean;
+  modelGenerator: generateFunc;
+}): Promise<AppContext>;

--- a/test-packages/test-utils/src/api.ts
+++ b/test-packages/test-utils/src/api.ts
@@ -29,3 +29,4 @@ export {
   expectExists,
   expectProperty,
 } from "./utils/expect";
+export { getContextForFile } from "./utils/context";

--- a/test-packages/test-utils/src/utils/context.ts
+++ b/test-packages/test-utils/src/utils/context.ts
@@ -1,0 +1,25 @@
+import type { generateFunc, TestModelVersion } from "../../api";
+import type {
+  AppContext,
+  UI5Framework,
+} from "@ui5-language-assistant/semantic-model-types";
+import { generateModel } from "./semantic-model-provider";
+
+export async function getContextForFile(opts: {
+  framework: UI5Framework;
+  version: TestModelVersion;
+  downloadLibs?: boolean;
+  strict?: boolean;
+  modelGenerator: generateFunc;
+}): Promise<AppContext> {
+  const { framework, version, modelGenerator, downloadLibs, strict } = opts;
+  const ui5Model = await generateModel({
+    framework,
+    version,
+    modelGenerator,
+    downloadLibs,
+    strict,
+  });
+
+  return { ui5Model };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8841,11 +8841,6 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"


### PR DESCRIPTION
- app context only contains UI5 model and manifest details
- fix getting correct UI5 version on initial load
- place caching logic in a single file