### PR TITLE
fix: show ui diagnostics if minUI5 version undefined in manifest.json or unsupported

### DIFF
--- a/packages/context/src/ui5-model.ts
+++ b/packages/context/src/ui5-model.ts
@@ -434,9 +434,13 @@ export async function negotiateVersionWithFetcher(
     } else {
       // development scenario => use latest version
       version = versionMap["latest"].version;
+      isIncorrectVersion = true;
     }
     // store the resolved version
     if (requestedVersion) {
+      if (requestedVersion !== version) {
+        isIncorrectVersion = true;
+      }
       resolvedVersions[requestedVersion] = version;
     }
   }

--- a/packages/context/test/ui5-model-spec.ts
+++ b/packages/context/test/ui5-model-spec.ts
@@ -279,180 +279,188 @@ describe("the UI5 language assistant ui5 model", () => {
     });
 
     it("resolve the default version", async () => {
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionInfo);
-          },
-          cachePath,
-          FRAMEWORK,
-          VERSION
-        )
-      ).to.be.equal(VERSION);
+      const objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionInfo);
+        },
+        cachePath,
+        FRAMEWORK,
+        VERSION
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal(VERSION);
     });
 
     it("resolve available concrete version (1.105.0)", async () => {
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionInfo);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1.105.0"
-        )
-      ).to.be.equal("1.105.0");
+      const objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionInfo);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1.105.0"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.105.0");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.false;
     });
 
     it("resolve available concrete version (1.104.0)", async () => {
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionInfo);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1.104.0"
-        )
-      ).to.be.equal("1.104.0");
+      const objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionInfo);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1.104.0"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.104.0");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.false;
     });
 
     it("resolve not available concrete version (should be latest)", async () => {
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1.104.0"
-        )
-      ).to.be.equal("1.105.0");
+      const objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1.104.0"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.105.0");
     });
 
     it("resolve major.minor versions (should be closest)", async () => {
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1.103"
-        )
-      ).to.be.equal("1.105.0");
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1.96"
-        )
-      ).to.be.equal("1.96.11");
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1.84"
-        )
-      ).to.be.equal("1.84.27");
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1.71"
-        )
-      ).to.be.equal("1.71.50");
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1.18"
-        )
-      ).to.be.equal("1.71.50");
+      let objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1.103"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.105.0");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.true;
+      objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1.96"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.96.11");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.true;
+      objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1.84"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.84.27");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.true;
+      objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1.71"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.71.50");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.true;
+      objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1.18"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.71.50");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.true;
     });
 
     it("resolve major version (should be closest)", async () => {
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          "1"
-        )
-      ).to.be.equal("1.71.50");
+      const objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        "1"
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.71.50");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.true;
     });
 
     it("resolve invalid versions (should be latest)", async () => {
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          ""
-        )
-      ).to.be.equal("1.71.49");
-      expect(
-        await negotiateVersionWithFetcher(
-          async (): Promise<FetchResponse> => {
-            return createResponse(true, 200, versionMap);
-          },
-          async (): Promise<FetchResponse> => {
-            return createResponse(false, 404);
-          },
-          cachePath,
-          FRAMEWORK,
-          undefined
-        )
-      ).to.be.equal("1.71.49");
+      let objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        ""
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.71.49");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.true;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.false;
+      objNegotiatedVersionWithFetcher = await negotiateVersionWithFetcher(
+        async (): Promise<FetchResponse> => {
+          return createResponse(true, 200, versionMap);
+        },
+        async (): Promise<FetchResponse> => {
+          return createResponse(false, 404);
+        },
+        cachePath,
+        FRAMEWORK,
+        undefined
+      );
+      expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.71.49");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.true;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.false;
     });
   });
 });

--- a/packages/context/test/ui5-model-spec.ts
+++ b/packages/context/test/ui5-model-spec.ts
@@ -340,6 +340,8 @@ describe("the UI5 language assistant ui5 model", () => {
         "1.104.0"
       );
       expect(objNegotiatedVersionWithFetcher.version).to.be.equal("1.105.0");
+      expect(objNegotiatedVersionWithFetcher.isFallback).to.be.false;
+      expect(objNegotiatedVersionWithFetcher.isIncorrectVersion).to.be.true;
     });
 
     it("resolve major.minor versions (should be closest)", async () => {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -123,10 +123,14 @@ connection.onCompletion(
       );
       const version = context.ui5Model.version;
       const framework = context.yamlDetails.framework;
+      const isFallback = context.ui5Model.isFallback;
+      const isIncorrectVersion = context.ui5Model.isIncorrectVersion;
       connection.sendNotification("UI5LanguageAssistant/ui5Model", {
         url: getCDNBaseUrl(framework, version),
         framework,
         version,
+        isFallback,
+        isIncorrectVersion,
       });
       ensureDocumentSettingsUpdated(document.uri);
       const documentSettings = await getSettingsForDocument(document.uri);
@@ -168,10 +172,14 @@ connection.onHover(
       );
       const version = context.ui5Model.version;
       const framework = context.yamlDetails.framework;
+      const isFallback = context.ui5Model.isFallback;
+      const isIncorrectVersion = context.ui5Model.isIncorrectVersion;
       connection.sendNotification("UI5LanguageAssistant/ui5Model", {
         url: getCDNBaseUrl(framework, version),
         framework,
         version,
+        isFallback,
+        isIncorrectVersion,
       });
       const hoverResponse = getHoverResponse(
         context,
@@ -230,10 +238,14 @@ documents.onDidChangeContent(async (changeEvent) => {
     );
     const version = context.ui5Model.version;
     const framework = context.yamlDetails.framework;
+    const isFallback = context.ui5Model.isFallback;
+    const isIncorrectVersion = context.ui5Model.isIncorrectVersion;
     connection.sendNotification("UI5LanguageAssistant/ui5Model", {
       url: getCDNBaseUrl(framework, version),
       framework,
       version,
+      isFallback,
+      isIncorrectVersion,
     });
     const diagnostics = getXMLViewDiagnostics({
       document,
@@ -260,10 +272,14 @@ connection.onCodeAction(async (params) => {
   );
   const version = context.ui5Model.version;
   const framework = context.yamlDetails.framework;
+  const isFallback = context.ui5Model.isFallback;
+  const isIncorrectVersion = context.ui5Model.isIncorrectVersion;
   connection.sendNotification("UI5LanguageAssistant/ui5Model", {
     url: getCDNBaseUrl(framework, version),
     framework,
     version,
+    isFallback,
+    isIncorrectVersion,
   });
 
   const diagnostics = params.context.diagnostics;

--- a/packages/semantic-model-types/api.d.ts
+++ b/packages/semantic-model-types/api.d.ts
@@ -13,6 +13,9 @@ export interface UI5SemanticModel {
   typedefs: Record<string, UI5Typedef>;
   // Likely Not Relevant for XML.Views
   functions: Record<string, UI5Function>;
+  // to indicate if the minUI5 version is undefined, old or wrong in manifest, fallback to default
+  isFallback?: boolean;
+  isIncorrectVersion?: boolean;
 }
 
 export interface UI5Meta {

--- a/packages/semantic-model/api.d.ts
+++ b/packages/semantic-model/api.d.ts
@@ -21,6 +21,8 @@ export function generate(opts: {
   typeNameFix: TypeNameFix;
   strict: boolean;
   printValidationErrors?: boolean;
+  isFallback?: boolean;
+  isIncorrectVersion?: boolean;
 }): UI5SemanticModel;
 
 /**

--- a/packages/semantic-model/src/api.ts
+++ b/packages/semantic-model/src/api.ts
@@ -18,12 +18,16 @@ export function generate({
   typeNameFix,
   strict,
   printValidationErrors = true,
+  isFallback,
+  isIncorrectVersion,
 }: {
   version: string;
   libraries: Record<string, Json>;
   typeNameFix: TypeNameFix;
   strict: boolean;
   printValidationErrors?: boolean;
+  isFallback?: boolean;
+  isIncorrectVersion?: boolean;
 }): UI5SemanticModel {
   const jsonSymbols = newMap<ConcreteSymbol>();
   const model = convertToSemanticModel(
@@ -35,6 +39,8 @@ export function generate({
   generateMissingSymbols(model, strict);
   resolveSemanticProperties(model, jsonSymbols, typeNameFix, strict);
   model.version = version;
+  model.isFallback = isFallback;
+  model.isIncorrectVersion = isIncorrectVersion;
   return deepFreezeStrict(model);
 }
 

--- a/packages/vscode-ui5-language-assistant/src/extension.ts
+++ b/packages/vscode-ui5-language-assistant/src/extension.ts
@@ -131,7 +131,7 @@ function updateCurrentModel(model: UI5Model | undefined) {
       }
 
       if (currentModel.isIncorrectVersion) {
-        tooltipText += ` minUI5 version found in manifest.json is out of maintenance or not supported by UI5 Language Assistant. Using fallback to UI5 ${currentModel.version}. Please update the minUI5 version`;
+        tooltipText += ` minUI5 version found in manifest.json is out of maintenance or not supported by UI5 Language Assistant. Using fallback to UI5 ${currentModel.version}.`;
         version = `Fallback: ${currentModel.version}`;
       }
 

--- a/packages/vscode-ui5-language-assistant/src/extension.ts
+++ b/packages/vscode-ui5-language-assistant/src/extension.ts
@@ -24,7 +24,13 @@ import {
 } from "@ui5-language-assistant/language-server";
 import { COMMAND_OPEN_DEMOKIT, LOGGING_LEVEL_CONFIG_PROP } from "./constants";
 
-type UI5Model = { url: string; framework: string; version: string };
+type UI5Model = {
+  url: string;
+  framework: string;
+  version: string;
+  isFallback: boolean;
+  isIncorrectVersion?: boolean;
+};
 
 let client: LanguageClient;
 let statusBarItem: StatusBarItem;
@@ -117,8 +123,20 @@ function updateCurrentModel(model: UI5Model | undefined) {
   currentModel = model;
   if (statusBarItem) {
     if (currentModel) {
-      statusBarItem.tooltip = `${currentModel.framework} Version (XMLView Editor)`;
-      statusBarItem.text = `$(notebook-mimetype) ${currentModel.version}${
+      let tooltipText = `${currentModel.framework} Version (XMLView Editor)`;
+      let version = currentModel.version;
+      if (currentModel.isFallback) {
+        tooltipText += ` minUI5 version not found in manifest.json. Fallback to UI5 ${currentModel.version}`;
+        version = `Fallback: ${currentModel.version}`;
+      }
+
+      if (currentModel.isIncorrectVersion) {
+        tooltipText += ` minUI5 version found in manifest.json is out of maintenance or not supported by UI5 Language Assistant. Using fallback to UI5 ${currentModel.version}. Please update the minUI5 version`;
+        version = `Fallback: ${currentModel.version}`;
+      }
+
+      statusBarItem.tooltip = tooltipText;
+      statusBarItem.text = `$(notebook-mimetype)  ${version}${
         currentModel.framework === "OpenUI5" ? "'" : ""
       }`;
       statusBarItem.show();


### PR DESCRIPTION
Make the implementation more robust and provide additional diagnostics for

- UI5 version is not available in the project manifest.json ->Notify the user about fallback to default
- UI5 version available in project, but api.json is not available (old or wrong versions case)