### PR TITLE
fix: clear diagnostics for a closed file

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -330,6 +330,11 @@ documents.onDidClose((textDocumentChangeEvent) => {
   getLogger().debug("`onDidClose` event", {
     textDocumentChangeEvent,
   });
+  const uri = textDocumentChangeEvent.document.uri;
+  if (isXMLView(uri)) {
+    // clear diagnostics for a closed file
+    connection.sendDiagnostics({ uri, diagnostics: [] });
+  }
   clearDocumentSettings(textDocumentChangeEvent.document.uri);
 });
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -335,7 +335,7 @@ documents.onDidClose((textDocumentChangeEvent) => {
     // clear diagnostics for a closed file
     connection.sendDiagnostics({ uri, diagnostics: [] });
   }
-  clearDocumentSettings(textDocumentChangeEvent.document.uri);
+  clearDocumentSettings(uri);
 });
 
 documents.listen(connection);


### PR DESCRIPTION
Currently if an `.view.xml` or `.fragment.xml` is closed, its diagnostic is not cleared out. This will clear out diagnostics of an `.view.xml` or `.fragment.xml` file.