### PR TITLE
ci: fix ghr publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
 
   deploy-gh-releases:
     docker:
-      - image: cimg/go:1.16
+      - image: cimg/go:1.17
     steps:
       - attach_workspace:
           at: ./artifacts


### PR DESCRIPTION
publishing to github fails due to go lang version.