### PR TITLE
fix: crash with no default model

### DIFF
--- a/packages/context/src/manifest.ts
+++ b/packages/context/src/manifest.ts
@@ -98,7 +98,7 @@ export async function getUI5Manifest(
  */
 export function getMainService(manifest: Manifest): string | undefined {
   const model = manifest["sap.ovp"]?.globalFilterModel ?? "";
-  return manifest["sap.ui5"]?.models?.[model].dataSource;
+  return manifest["sap.ui5"]?.models?.[model]?.dataSource;
 }
 /**
  * Get service path defined under `sap.app->dataSources`

--- a/packages/context/test/manifest-spec.ts
+++ b/packages/context/test/manifest-spec.ts
@@ -80,10 +80,26 @@ describe("manifest", () => {
       minUI5Version: "1.108.1",
     });
   });
-  it("getMainService", async () => {
-    const { manifest } = await getProjectData(testFramework.getProjectRoot());
-    const result = await getMainService(manifest);
-    expect(result).to.equal("mainService");
+  describe("getMainService", () => {
+    it("manifest without model definitions", async () => {
+      const result = getMainService({
+        "sap.ui5": {},
+      } as never);
+      expect(result).to.equal(undefined);
+    });
+    it("manifest without default model", async () => {
+      const result = getMainService({
+        "sap.ui5": {
+          models: {},
+        },
+      } as never);
+      expect(result).to.equal(undefined);
+    });
+    it("complete manifest", async () => {
+      const { manifest } = await getProjectData(testFramework.getProjectRoot());
+      const result = getMainService(manifest);
+      expect(result).to.equal("mainService");
+    });
   });
   it("getServicePath", async () => {
     const { manifest } = await getProjectData(testFramework.getProjectRoot());


### PR DESCRIPTION
Fixes #552

Added additional checks to avoid crashing if default model (with name "") does not exist. 