### PR TITLE
fix: project root resolution

### DIFF
--- a/packages/context/src/utils/project.ts
+++ b/packages/context/src/utils/project.ts
@@ -42,10 +42,7 @@ export async function getProjectRoot(
 ): Promise<string | undefined> {
   let projectRoot: string | undefined;
   try {
-    projectRoot = await findProjectRoot(documentPath, true);
-    if (!projectRoot) {
-      projectRoot = await findProjectRoot(documentPath, false);
-    }
+    projectRoot = await findProjectRoot(documentPath, false);
   } catch (error) {
     getLogger().debug("getProjectRoot failed:", error);
     projectRoot = undefined;

--- a/packages/context/src/utils/project.ts
+++ b/packages/context/src/utils/project.ts
@@ -42,6 +42,15 @@ export async function getProjectRoot(
 ): Promise<string | undefined> {
   let projectRoot: string | undefined;
   try {
+    projectRoot = await findProjectRoot(documentPath, true);
+  } catch (error) {
+    getLogger().debug("getProjectRoot failed:", error);
+    projectRoot = undefined;
+  }
+  if (projectRoot !== undefined) {
+    return projectRoot;
+  }
+  try {
     projectRoot = await findProjectRoot(documentPath, false);
   } catch (error) {
     getLogger().debug("getProjectRoot failed:", error);

--- a/packages/context/test/utils/project-spec.ts
+++ b/packages/context/test/utils/project-spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { join } from "path";
+import { homedir } from "os";
 import {
   findAppRoot,
   getLocalAnnotationsForService,
@@ -31,8 +32,8 @@ describe.only("project", () => {
     testFramework = new TestFramework(useConfig);
   });
   context("getProjectRoot", () => {
-    it("throws exception and return undefined", async () => {
-      const result = await getProjectRoot(__dirname);
+    it("return undefined when no package.json is found", async () => {
+      const result = await getProjectRoot(homedir());
       expect(result).to.be.undefined;
     });
     it("return project root ", async () => {

--- a/packages/context/test/utils/project-spec.ts
+++ b/packages/context/test/utils/project-spec.ts
@@ -42,6 +42,19 @@ describe.only("project", () => {
       const result = await getProjectRoot(docPath);
       expect(result).to.equal(projectRoot);
     });
+    it("free style project", async () => {
+      const framework = new TestFramework({
+        projectInfo: {
+          name: ProjectName.tsFreeStyle,
+          type: ProjectType.UI5,
+          npmInstall: false,
+        },
+      });
+      const projectRoot = framework.getProjectRoot();
+      const documentPath = join(projectRoot, "src", "view", "Main.view.xml");
+      const result = await getProjectRoot(documentPath);
+      expect(result).to.equal(projectRoot);
+    });
   });
   context("getProjectInfo", () => {
     it("undefined", async () => {


### PR DESCRIPTION
Issue: #556

When trying to resolve project root, we were looking for SAP Fiori elements applications by default and if it failed then free style applications were ignored. Now we look for any application by default.