### PR TITLE
fix: npm publish fix

### DIFF
--- a/.changeset/funny-tables-impress.md
+++ b/.changeset/funny-tables-impress.md
@@ -1,0 +1,6 @@
+---
+"vscode-ui5-language-assistant": patch
+"@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext": patch
+---
+
+npmjs publish fix

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build:quick": "lerna run compile && lerna run bundle && lerna run package",
     "release:version": "lerna version --force-publish",
-    "release:publish": "lerna publish from-git --yes",
+    "release:publish": "lerna publish from-package --yes",
     "ci": "npm-run-all format:validate ci:subpackages coverage:merge legal:*",
     "compile": "yarn run clean && tsc --build",
     "compile:watch": "yarn run clean && tsc --build --watch",


### PR DESCRIPTION
Publishing github action is unable to detect changes. This pr contains fix for lerna publish command which is used in the workflow