### PR TITLE
Fix: some issues

### DIFF
--- a/.changeset/eleven-items-turn.md
+++ b/.changeset/eleven-items-turn.md
@@ -1,0 +1,7 @@
+---
+"@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext": patch
+"vscode-ui5-language-assistant": patch
+"@ui5-language-assistant/binding": patch
+---
+
+Address some issues

--- a/packages/binding/src/services/completion/providers/create-value.ts
+++ b/packages/binding/src/services/completion/providers/create-value.ts
@@ -8,6 +8,7 @@ import {
   isPrimitiveValue,
   isStructureValue,
   positionContained,
+  isBefore,
   BindingParserTypes as BindingTypes,
 } from "@ui5-language-assistant/binding-parser";
 
@@ -15,6 +16,27 @@ import { propertyBindingInfoElements } from "../../../definition/definition";
 import { isParts, typesToValue } from "../../../utils";
 import { getCompletionItems } from "./property-binding-info";
 import { BindContext, ValueContext } from "../../../types";
+
+const getCollectionCompletionItem = (
+  context: BindContext,
+  element: BindingTypes.StructureElement
+): CompletionItem[] => {
+  const bindingElement = propertyBindingInfoElements.find(
+    (el) => el.name === (element.key && element.key.text)
+  );
+  const data = typesToValue(
+    /* istanbul ignore next */
+    bindingElement?.type ?? [],
+    context,
+    true
+  );
+  return data.map((item) => ({
+    label: item,
+    insertTextFormat: InsertTextFormat.Snippet,
+    insertText: item,
+    kind: CompletionItemKind.Field,
+  }));
+};
 
 export const createValue = (
   context: BindContext,
@@ -53,6 +75,7 @@ export const createValue = (
       }
       completionItems.push(data);
     }
+    return completionItems;
   }
   if (!element.value) {
     // if value is missing, provide a value
@@ -71,40 +94,41 @@ export const createValue = (
         });
       });
     }
-  } else if (isCollectionValue(element.value) && isParts(element)) {
+    return completionItems;
+  }
+  if (isCollectionValue(element.value) && isParts(element)) {
     /* istanbul ignore next */
     const position = context.textDocumentPosition?.position;
-    if (position) {
-      const el = element.value.elements
-        .filter((item) => !!item)
-        .find((item) => positionContained(item.range, position));
-
-      if (isStructureValue(el)) {
-        const result = getCompletionItems(context, el, spaces).filter(
-          (item) => item.label !== "parts"
-        );
-        completionItems.push(...result);
-      }
-      if (!el) {
-        const bindingElement = propertyBindingInfoElements.find(
-          (el) => el.name === (element.key && element.key.text)
-        );
-        const data = typesToValue(
-          /* istanbul ignore next */
-          bindingElement?.type ?? [],
-          context,
-          true
-        );
-        data.forEach((item) =>
-          completionItems.push({
-            label: item,
-            insertTextFormat: InsertTextFormat.Snippet,
-            insertText: item,
-            kind: CompletionItemKind.Field,
-          })
-        );
-      }
+    if (!position) {
+      return completionItems;
     }
+    const el = element.value.elements
+      .filter((item) => !!item)
+      .find((item) => positionContained(item.range, position));
+
+    if (isStructureValue(el)) {
+      // check if position is outside {}
+      if (
+        (el.leftCurly && isBefore(position, el.leftCurly.range.start, true)) ||
+        (el.rightCurly && isBefore(el.rightCurly.range.end, position, true))
+      ) {
+        return getCollectionCompletionItem(context, element);
+      }
+      const result = getCompletionItems(context, el, spaces).filter(
+        (item) => item.label !== "parts"
+      );
+      return result;
+    }
+    // check if position is outside []
+    if (
+      element.value.range &&
+      (isBefore(position, element.value.range.start, true) ||
+        isBefore(element.value.range.end, position, true))
+    ) {
+      return completionItems;
+    }
+
+    return getCollectionCompletionItem(context, element);
   }
   return completionItems;
 };

--- a/packages/binding/src/services/completion/providers/create-value.ts
+++ b/packages/binding/src/services/completion/providers/create-value.ts
@@ -107,11 +107,11 @@ export const createValue = (
       .find((item) => positionContained(item.range, position));
 
     if (isStructureValue(el)) {
-      // check if position is outside {}
       if (
         (el.leftCurly && isBefore(position, el.leftCurly.range.start, true)) ||
         (el.rightCurly && isBefore(el.rightCurly.range.end, position, true))
       ) {
+        // position is outside {}
         return getCollectionCompletionItem(context, element);
       }
       const result = getCompletionItems(context, el, spaces).filter(
@@ -119,12 +119,12 @@ export const createValue = (
       );
       return result;
     }
-    // check if position is outside []
     if (
       element.value.range &&
       (isBefore(position, element.value.range.start, true) ||
         isBefore(element.value.range.end, position, true))
     ) {
+      // position is outside []
       return completionItems;
     }
 

--- a/packages/binding/src/services/completion/providers/create-value.ts
+++ b/packages/binding/src/services/completion/providers/create-value.ts
@@ -10,6 +10,7 @@ import {
   positionContained,
   isBefore,
   BindingParserTypes as BindingTypes,
+  rangeContained,
 } from "@ui5-language-assistant/binding-parser";
 
 import { propertyBindingInfoElements } from "../../../definition/definition";
@@ -128,7 +129,10 @@ export const createValue = (
       // position is outside []
       return completionItems;
     }
-
+    if (el && rangeContained(el.range, { start: position, end: position })) {
+      // on primitive value e.g '|'
+      return completionItems;
+    }
     return getCollectionCompletionItem(context, element);
   }
   return completionItems;

--- a/packages/binding/src/services/completion/providers/create-value.ts
+++ b/packages/binding/src/services/completion/providers/create-value.ts
@@ -14,12 +14,12 @@ import {
 import { propertyBindingInfoElements } from "../../../definition/definition";
 import { isParts, typesToValue } from "../../../utils";
 import { getCompletionItems } from "./property-binding-info";
-import { BindContext, ColonContext, ValueContext } from "../../../types";
+import { BindContext, ValueContext } from "../../../types";
 
 export const createValue = (
   context: BindContext,
   spaces: BindingTypes.WhiteSpaces[],
-  valueContext: ValueContext | ColonContext
+  valueContext: ValueContext
 ): CompletionItem[] => {
   const completionItems: CompletionItem[] = [];
   const { element } = valueContext;

--- a/packages/binding/src/services/completion/providers/property-binding-info.ts
+++ b/packages/binding/src/services/completion/providers/property-binding-info.ts
@@ -88,8 +88,7 @@ export function propertyBindingInfoSuggestions({
       completionItems.push(...createInitialSnippet());
       continue;
     }
-    const cursorPos =
-      context.textDocumentPosition && context.textDocumentPosition.position;
+    const cursorPos = context.textDocumentPosition?.position;
     const binding = ast.bindings.find(
       (b) => cursorPos && positionContained(b.range, cursorPos)
     );

--- a/packages/binding/src/services/completion/providers/property-binding-info.ts
+++ b/packages/binding/src/services/completion/providers/property-binding-info.ts
@@ -45,12 +45,6 @@ export const getCompletionItems = (
       return createValue(context, spaces, cursorContext);
     case "key-value":
       return createKeyValue(context, binding);
-    case "colon":
-      if (!cursorContext.element.value) {
-        // create value
-        return createValue(context, spaces, cursorContext);
-      }
-      return completionItems;
     default:
       break;
   }

--- a/packages/binding/src/services/completion/providers/property-binding-info.ts
+++ b/packages/binding/src/services/completion/providers/property-binding-info.ts
@@ -1,6 +1,7 @@
 import {
   parseBinding,
   BindingParserTypes as BindingTypes,
+  positionContained,
 } from "@ui5-language-assistant/binding-parser";
 import type { Position } from "vscode-languageserver-types";
 import { AttributeValueCompletionOptions } from "@xml-tools/content-assist";
@@ -93,21 +94,18 @@ export function propertyBindingInfoSuggestions({
       completionItems.push(...createInitialSnippet(context));
       continue;
     }
-    for (const binding of ast.bindings) {
-      if (!isPropertyBindingInfo(text, binding)) {
-        continue;
-      }
-      completionItems.push(...getCompletionItems(context, binding, ast.spaces));
+    const cursorPos =
+      context.textDocumentPosition && context.textDocumentPosition.position;
+    const binding = ast.bindings.find(
+      (b) => cursorPos && positionContained(b.range, cursorPos)
+    );
+    if (!binding) {
+      continue;
     }
+    if (!isPropertyBindingInfo(text, binding)) {
+      continue;
+    }
+    completionItems.push(...getCompletionItems(context, binding, ast.spaces));
   }
-  const nonDuplicateItems = completionItems.reduce(
-    (previous: CompletionItem[], current: CompletionItem) => {
-      if (previous.findIndex((item) => item.label === current.label) === -1) {
-        previous.push(current);
-      }
-      return previous;
-    },
-    []
-  );
-  return nonDuplicateItems;
+  return completionItems;
 }

--- a/packages/binding/src/services/diagnostics/validators/check-brackets.ts
+++ b/packages/binding/src/services/diagnostics/validators/check-brackets.ts
@@ -1,0 +1,34 @@
+import { BindingIssue, BINDING_ISSUE_TYPE } from "../../../types";
+import {
+  isStructureValue,
+  BindingParserTypes as BindingTypes,
+} from "@ui5-language-assistant/binding-parser";
+import { findRange } from "../../../utils";
+export const checkBrackets = (
+  binding: BindingTypes.StructureValue | BindingTypes.CollectionValue
+): BindingIssue[] => {
+  const issues: BindingIssue[] = [];
+  if (isStructureValue(binding)) {
+    if (!binding.rightCurly || binding.rightCurly.text === "") {
+      issues.push({
+        issueType: BINDING_ISSUE_TYPE,
+        kind: "MissingBracket",
+        message: "Expect closing brace",
+        range: findRange([binding.range]),
+        severity: "error",
+      });
+    }
+    return issues;
+  }
+  if (!binding.rightSquare || binding.rightSquare.text === "") {
+    issues.push({
+      issueType: BINDING_ISSUE_TYPE,
+      kind: "MissingBracket",
+      message: "Expect closing bracket",
+      range: findRange([binding.range]),
+      severity: "error",
+    });
+  }
+
+  return issues;
+};

--- a/packages/binding/src/services/diagnostics/validators/check-collection-value.ts
+++ b/packages/binding/src/services/diagnostics/validators/check-collection-value.ts
@@ -10,6 +10,7 @@ import { getPrimitiveValueIssues } from "./check-primitive-value";
 import { propertyBindingInfoElements } from "../../../definition/definition";
 import { isParts, typesToValue, findRange } from "../../../utils";
 import { checkComma } from "./check-comma";
+import { checkBrackets } from "./check-brackets";
 
 /**
  * Check collection value
@@ -31,6 +32,7 @@ export const checkCollectionValue = (
   if (!isCollectionValue(value)) {
     return issues;
   }
+  issues.push(...checkBrackets(value));
   // filter undefined
   const elements = value.elements.filter((item) => !!item);
   if (ignore) {

--- a/packages/binding/src/services/diagnostics/validators/check-key.ts
+++ b/packages/binding/src/services/diagnostics/validators/check-key.ts
@@ -1,6 +1,7 @@
 import { propertyBindingInfoElements } from "../../../definition/definition";
 import { BindingIssue, BINDING_ISSUE_TYPE } from "../../../types";
 import { BindingParserTypes as BindingTypes } from "@ui5-language-assistant/binding-parser";
+import { findRange } from "../../../utils";
 /**
  * Check if key is a one of supported property binding info
  */
@@ -9,6 +10,13 @@ export const checkKey = (
 ): BindingIssue[] => {
   const issues: BindingIssue[] = [];
   if (!element.key) {
+    issues.push({
+      issueType: BINDING_ISSUE_TYPE,
+      kind: "MissingKey",
+      message: "Expect key",
+      range: findRange([element.colon?.range, element.value?.range]),
+      severity: "error",
+    });
     return issues;
   }
   const text = element.key && element.key.text;

--- a/packages/binding/src/services/diagnostics/validators/issue-collector.ts
+++ b/packages/binding/src/services/diagnostics/validators/issue-collector.ts
@@ -11,6 +11,7 @@ import { checkNotAllowedElement } from "./check-not-allowed-element";
 import { checkDependents } from "./check-dependents";
 import { checkNestedParts } from "./check-nested-parts";
 import { checkComma } from "./check-comma";
+import { checkBrackets } from "./check-brackets";
 
 /**
  * Check an AST
@@ -63,5 +64,6 @@ export const checkAst = (
   issues.push(...checkNotAllowedElement(binding));
   issues.push(...checkDependents(context, binding));
   issues.push(...checkNestedParts(binding));
+  issues.push(...checkBrackets(binding));
   return issues;
 };

--- a/packages/binding/src/services/diagnostics/validators/property-binding-info-validator.ts
+++ b/packages/binding/src/services/diagnostics/validators/property-binding-info-validator.ts
@@ -57,6 +57,9 @@ export function validatePropertyBindingInfo(
          * Show all lexer errors
          */
         for (const item of filterLexerError(binding, errors)) {
+          if (binding.elements.length === 0) {
+            return issues;
+          }
           issues.push({
             issueType: BINDING_ISSUE_TYPE,
             kind: "UnknownChar",

--- a/packages/binding/src/types/cursor.ts
+++ b/packages/binding/src/types/cursor.ts
@@ -45,6 +45,9 @@ export interface KeyContext extends BaseContext {
  *
  * e. keyProperty: 'value-for-this-key'`<CURSOR>`
  *
+ * g. keyProperty `<CURSOR>` 'value-for-this-key' [missing colon]
+ *
+ * h. keyProperty `<CURSOR>` [space(s)] [missing colon]
  */
 export interface ValueContext extends BaseContext {
   type: "value";
@@ -61,35 +64,13 @@ export interface ValueContext extends BaseContext {
  *
  * d. keyProperty: 'value-for-this-key',`<CURSOR>`, [between comma]
  */
-export interface KeyValueContext extends BaseContext {
+export interface KeyValueContext {
   type: "key-value";
   kind: "properties-with-value-excluding-duplicate";
 }
-
-/**
- * Colon context scenario
- *
- * a. keyProperty `<CURSOR>` 'value-for-this-key'
- *
- * b. keyProperty `<CURSOR>` [space(s)]
- */
-export interface ColonContext extends BaseContext {
-  type: "colon";
-  kind: "colon";
-}
-/**
- * Unknown context. Any context except above is unknown and not code completion is provided
- */
-export interface UnknownContext {
-  type: "unknown";
-  kind: "unknown";
-}
-
 export type CursorContext =
   | InitialContext
   | EmptyContext
   | KeyContext
   | ValueContext
-  | KeyValueContext
-  | ColonContext
-  | UnknownContext;
+  | KeyValueContext;

--- a/packages/binding/src/types/index.ts
+++ b/packages/binding/src/types/index.ts
@@ -14,11 +14,9 @@ export type {
   CursorContext,
   KeyValueContext,
   BaseContext,
-  ColonContext,
   EmptyContext,
   InitialContext,
   KeyContext,
-  UnknownContext,
   ValueContext,
 } from "./cursor";
 

--- a/packages/binding/src/types/issues.ts
+++ b/packages/binding/src/types/issues.ts
@@ -19,7 +19,7 @@ export type BindingIssue =
   | RequiredDependency
   | RecursiveProperty
   | Unnecessary
-  | MissingLeftCurly;
+  | MissingBracket;
 
 interface BaseUI5XMLViewBindingIssue {
   issueType: typeof BINDING_ISSUE_TYPE;
@@ -50,8 +50,8 @@ export interface TooManyCommas extends BaseUI5XMLViewBindingIssue {
 export interface TrailingComma extends BaseUI5XMLViewBindingIssue {
   kind: "TrailingComma";
 }
-export interface MissingLeftCurly extends BaseUI5XMLViewBindingIssue {
-  kind: "MissingLeftCurly";
+export interface MissingBracket extends BaseUI5XMLViewBindingIssue {
+  kind: "MissingBracket";
 }
 /**
  * All parser error

--- a/packages/binding/src/utils/cursor.ts
+++ b/packages/binding/src/utils/cursor.ts
@@ -24,7 +24,7 @@ export const getCursorContext = (
   const el = elements.find((item) => positionContained(item.range, position));
   if (el) {
     // check key
-    if (positionContained(el.key && el.key.range, position)) {
+    if (positionContained(el.key?.range, position)) {
       return {
         type: "key",
         kind: "properties-excluding-duplicate",
@@ -32,7 +32,7 @@ export const getCursorContext = (
       };
     }
     // check colon => value
-    if (positionContained(el.colon && el.colon.range, position)) {
+    if (positionContained(el.colon?.range, position)) {
       return {
         type: "value",
         kind: "value",
@@ -40,7 +40,7 @@ export const getCursorContext = (
       };
     }
     // check value
-    if (positionContained(el.value && el.value.range, position)) {
+    if (positionContained(el.value?.range, position)) {
       return {
         type: "value",
         kind: "value",
@@ -56,7 +56,7 @@ export const getCursorContext = (
     // further check parts of adjacent element
     for (const el of elements) {
       // after adjacent key => value
-      if (isAfterAdjacentRange(spaceEl.range, el.key && el.key.range)) {
+      if (isAfterAdjacentRange(spaceEl.range, el.key?.range)) {
         // this happen when colon is missing
         return {
           type: "value",
@@ -65,7 +65,7 @@ export const getCursorContext = (
         };
       }
       // after adjacent colon => value
-      if (isAfterAdjacentRange(spaceEl.range, el.colon && el.colon.range)) {
+      if (isAfterAdjacentRange(spaceEl.range, el.colon?.range)) {
         return {
           type: "value",
           kind: "value",

--- a/packages/binding/src/utils/cursor.ts
+++ b/packages/binding/src/utils/cursor.ts
@@ -31,6 +31,14 @@ export const getCursorContext = (
         element: el,
       };
     }
+    // check colon => value
+    if (positionContained(el.colon && el.colon.range, position)) {
+      return {
+        type: "value",
+        kind: "value",
+        element: el,
+      };
+    }
     // check value
     if (positionContained(el.value && el.value.range, position)) {
       return {

--- a/packages/binding/test/unit/services/completion/index.test.ts
+++ b/packages/binding/test/unit/services/completion/index.test.ts
@@ -401,8 +401,8 @@ describe("index", () => {
         expect(
           result.map((item) => completionItemToSnapshot(item))
         ).toStrictEqual([
-          "label: { }; text: { }; kind:5; commit:undefined; sort:",
-          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
+          "label: {}; text: {$0}; kind:5; commit:undefined; sort:",
+          "label: ''; text: '$0'; kind:5; commit:undefined; sort:",
         ]);
       });
       it("n. for parts only [outside existing structure element(s) - case 02]", async function () {
@@ -412,8 +412,8 @@ describe("index", () => {
         expect(
           result.map((item) => completionItemToSnapshot(item))
         ).toStrictEqual([
-          "label: { }; text: { }; kind:5; commit:undefined; sort:",
-          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
+          "label: {}; text: {$0}; kind:5; commit:undefined; sort:",
+          "label: ''; text: '$0'; kind:5; commit:undefined; sort:",
         ]);
       });
       it("o. for parts only [outside existing primitive element(s) - case 01]", async function () {
@@ -423,8 +423,8 @@ describe("index", () => {
         expect(
           result.map((item) => completionItemToSnapshot(item))
         ).toStrictEqual([
-          "label: { }; text: { }; kind:5; commit:undefined; sort:",
-          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
+          "label: {}; text: {$0}; kind:5; commit:undefined; sort:",
+          "label: ''; text: '$0'; kind:5; commit:undefined; sort:",
         ]);
       });
       it("p. for parts only [outside existing primitive element(s) - case 02]", async function () {
@@ -434,8 +434,8 @@ describe("index", () => {
         expect(
           result.map((item) => completionItemToSnapshot(item))
         ).toStrictEqual([
-          "label: { }; text: { }; kind:5; commit:undefined; sort:",
-          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
+          "label: {}; text: {$0}; kind:5; commit:undefined; sort:",
+          "label: ''; text: '$0'; kind:5; commit:undefined; sort:",
         ]);
       });
     });
@@ -585,20 +585,20 @@ describe("index", () => {
         expect(
           result.map((item) => completionItemToSnapshot(item))
         ).toStrictEqual([
-          "label: value; text: value: ' '; kind:15; commit:undefined; sort:",
-          "label: model; text: model: ' '; kind:15; commit:undefined; sort:",
+          "label: value; text: value: '$0'; kind:15; commit:undefined; sort:",
+          "label: model; text: model: '$0'; kind:15; commit:undefined; sort:",
           "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: formatter; text: formatter: ' '; kind:15; commit:undefined; sort:",
+          "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:",
           "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
           "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: type; text: type: ${1|{ },' '|}$0; kind:15; commit:undefined; sort:",
-          "label: targetType; text: targetType: ' '; kind:15; commit:undefined; sort:",
-          "label: formatOptions; text: formatOptions: { }; kind:15; commit:undefined; sort:",
-          "label: constraints; text: constraints: { }; kind:15; commit:undefined; sort:",
-          "label: mode; text: mode: ' '; kind:15; commit:undefined; sort:",
-          "label: parameters; text: parameters: { }; kind:15; commit:undefined; sort:",
-          "label: events; text: events: { }; kind:15; commit:undefined; sort:",
-          "label: parts; text: parts: ${1|[{ }],[' ']|}$0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: ${1|{},''|}$0; kind:15; commit:undefined; sort:",
+          "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:",
+          "label: formatOptions; text: formatOptions: {$0}; kind:15; commit:undefined; sort:",
+          "label: constraints; text: constraints: {$0}; kind:15; commit:undefined; sort:",
+          "label: mode; text: mode: '$0'; kind:15; commit:undefined; sort:",
+          "label: parameters; text: parameters: {$0}; kind:15; commit:undefined; sort:",
+          "label: events; text: events: {$0}; kind:15; commit:undefined; sort:",
+          "label: parts; text: parts: ${1|[{}],['']|}$0; kind:15; commit:undefined; sort:",
         ]);
       });
       it("provides no CC for wrong context", async function () {
@@ -665,8 +665,8 @@ describe("index", () => {
         expect(
           result.map((item) => completionItemToSnapshot(item))
         ).toStrictEqual([
-          "label: { }; text: { }; kind:5; commit:undefined; sort:",
-          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
+          "label: {}; text: {$0}; kind:5; commit:undefined; sort:",
+          "label: ''; text: '$0'; kind:5; commit:undefined; sort:",
         ]);
       });
     });

--- a/packages/binding/test/unit/services/completion/index.test.ts
+++ b/packages/binding/test/unit/services/completion/index.test.ts
@@ -534,6 +534,29 @@ describe("index", () => {
           "label: parts; text: parts: ${1|[{ }],[' ']|}$0; kind:15; commit:undefined; sort:",
         ]);
       });
+      it("no double CC items for two or more empty binding [consider consumed properties]", async function () {
+        const snippet = `
+        <Text text="some text {} and some here {path: '', ${CURSOR_ANCHOR}}" id="test-id"></Text>`;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([
+          "label: value; text: value: ' '; kind:15; commit:undefined; sort:",
+          "label: model; text: model: ' '; kind:15; commit:undefined; sort:",
+          "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: formatter; text: formatter: ' '; kind:15; commit:undefined; sort:",
+          "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: ${1|{ },' '|}$0; kind:15; commit:undefined; sort:",
+          "label: targetType; text: targetType: ' '; kind:15; commit:undefined; sort:",
+          "label: formatOptions; text: formatOptions: { }; kind:15; commit:undefined; sort:",
+          "label: constraints; text: constraints: { }; kind:15; commit:undefined; sort:",
+          "label: mode; text: mode: ' '; kind:15; commit:undefined; sort:",
+          "label: parameters; text: parameters: { }; kind:15; commit:undefined; sort:",
+          "label: events; text: events: { }; kind:15; commit:undefined; sort:",
+          "label: parts; text: parts: ${1|[{ }],[' ']|}$0; kind:15; commit:undefined; sort:",
+        ]);
+      });
       it("provides no CC for wrong context", async function () {
         const snippet = `
        <Label text="Hello Mr. {${CURSOR_ANCHOR}/employees/0/lastName}, {path:'/employees/0/firstName', formatter:'.myFormatter'}"/>`;
@@ -588,6 +611,18 @@ describe("index", () => {
           "label: mode; text: mode; kind:5; commit:undefined; sort:; textEdit: {newText: mode, range: 9:59-9:63}",
           "label: parameters; text: parameters; kind:5; commit:undefined; sort:; textEdit: {newText: parameters, range: 9:59-9:63}",
           "label: events; text: events; kind:5; commit:undefined; sort:; textEdit: {newText: events, range: 9:59-9:63}",
+        ]);
+      });
+      it("no wrong completion items inside collection", async function () {
+        const snippet = `
+        <Text text="some text and {} some here {parts: [${CURSOR_ANCHOR}]}" id="test-id"></Text>"/>
+        `;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([
+          "label: { }; text: { }; kind:5; commit:undefined; sort:",
+          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
         ]);
       });
     });

--- a/packages/binding/test/unit/services/completion/index.test.ts
+++ b/packages/binding/test/unit/services/completion/index.test.ts
@@ -360,7 +360,7 @@ describe("index", () => {
           "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
         ]);
       });
-      it("h. for parts only [existing element(s) without comma]", async function () {
+      it("j. for parts only [existing element(s) without comma]", async function () {
         const snippet = `
         <Text text="{parts: [{} ${CURSOR_ANCHOR} ]}" id="test-id"></Text>`;
         const result = await getCompletionResult(snippet);
@@ -371,7 +371,7 @@ describe("index", () => {
           "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
         ]);
       });
-      it("i. for parts only [all binding info properties except parts itself]", async function () {
+      it("j. for parts only [all binding info properties except parts itself]", async function () {
         const snippet = `
         <Text text="{parts: [{${CURSOR_ANCHOR}}]}" id="test-id"></Text>`;
         const result = await getCompletionResult(snippet);
@@ -392,6 +392,66 @@ describe("index", () => {
           "label: mode; text: mode: ' '; kind:15; commit:undefined; sort:",
           "label: parameters; text: parameters: { }; kind:15; commit:undefined; sort:",
           "label: events; text: events: { }; kind:15; commit:undefined; sort:",
+        ]);
+      });
+      it("k. for parts no completion items [collection exist - outside - case 01]", async function () {
+        const snippet = `
+        <Text text="{parts: ['']${CURSOR_ANCHOR}}" id="test-id"></Text>`;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([]);
+      });
+      it("l. for parts no completion items [collection exist - outside - case 02]", async function () {
+        const snippet = `
+        <Text text="{parts: ${CURSOR_ANCHOR}['']}" id="test-id"></Text>`;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([]);
+      });
+      it("m. for parts only [outside existing structure element(s) - case 01]", async function () {
+        const snippet = `
+        <Text text="{parts: [{}${CURSOR_ANCHOR} ]}" id="test-id"></Text>`;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([
+          "label: { }; text: { }; kind:5; commit:undefined; sort:",
+          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
+        ]);
+      });
+      it("n. for parts only [outside existing structure element(s) - case 02]", async function () {
+        const snippet = `
+        <Text text="{parts: [${CURSOR_ANCHOR}{} ]}" id="test-id"></Text>`;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([
+          "label: { }; text: { }; kind:5; commit:undefined; sort:",
+          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
+        ]);
+      });
+      it("o. for parts only [outside existing primitive element(s) - case 01]", async function () {
+        const snippet = `
+        <Text text="{parts: [''${CURSOR_ANCHOR} ]}" id="test-id"></Text>`;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([
+          "label: { }; text: { }; kind:5; commit:undefined; sort:",
+          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
+        ]);
+      });
+      it("p. for parts only [outside existing primitive element(s) - case 02]", async function () {
+        const snippet = `
+        <Text text="{parts: [${CURSOR_ANCHOR}'' ]}" id="test-id"></Text>`;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([
+          "label: { }; text: { }; kind:5; commit:undefined; sort:",
+          "label: ' '; text: ' '; kind:5; commit:undefined; sort:",
         ]);
       });
     });

--- a/packages/binding/test/unit/services/completion/index.test.ts
+++ b/packages/binding/test/unit/services/completion/index.test.ts
@@ -282,6 +282,7 @@ describe("index", () => {
           "label: parts; text: parts; kind:5; commit:undefined; sort:; textEdit: {newText: parts, range: 9:22-9:26}",
         ]);
       });
+      it.todo("d.`<CURSOR>`: {} [missing key]");
     });
     describe("provides CC for value", () => {
       it("a. keyProperty: `<CURSOR>`", async function () {

--- a/packages/binding/test/unit/services/completion/index.test.ts
+++ b/packages/binding/test/unit/services/completion/index.test.ts
@@ -438,6 +438,14 @@ describe("index", () => {
           "label: ''; text: '$0'; kind:5; commit:undefined; sort:",
         ]);
       });
+      it("q. for parts only [on existing primitive element(s) - no completion item]", async function () {
+        const snippet = `
+        <Text text="{parts: ['${CURSOR_ANCHOR}' ]}" id="test-id"></Text>`;
+        const result = await getCompletionResult(snippet);
+        expect(
+          result.map((item) => completionItemToSnapshot(item))
+        ).toStrictEqual([]);
+      });
     });
     describe("provides CC for key value", () => {
       it("a. keyProperty: 'value-for-this-key'  `<CURSOR>` [spaces]", async function () {

--- a/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
+++ b/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
@@ -428,7 +428,7 @@ describe("property-binding-info-validator", () => {
     });
     it("check missing value", async () => {
       const snippet = `
-    <Text text="{ parts: [{ path: } }" id="test-id"></Text>`;
+    <Text text="{ parts: [{ path: }] }" id="test-id"></Text>`;
       const result = await validateView(snippet);
       expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
         "kind: MissingValue; text: Expect ' ' as a value; severity:error; range:9:28-9:33",
@@ -436,7 +436,7 @@ describe("property-binding-info-validator", () => {
     });
     it("check missing comma [parts]", async () => {
       const snippet = `
-    <Text text="{ parts: [{ path: '' events: {} }}" id="test-id"></Text>`;
+    <Text text="{ parts: [{ path: '' events: {} }]}" id="test-id"></Text>`;
       const result = await validateView(snippet);
       expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
         "kind: MissingComma; text: Missing comma; severity:error; range:9:37-9:47",
@@ -702,7 +702,7 @@ describe("property-binding-info-validator", () => {
       });
       it("check missing value", async () => {
         const snippet = `
-    <Text text="{ 'parts': [{ 'path': } }" id="test-id"></Text>`;
+    <Text text="{ 'parts': [{ 'path': }] }" id="test-id"></Text>`;
         const result = await validateView(snippet);
         expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
           "kind: MissingValue; text: Expect ' ' as a value; severity:error; range:9:30-9:37",
@@ -722,6 +722,52 @@ describe("property-binding-info-validator", () => {
         const result = await validateView(snippet);
         expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
           'kind: MissingValue; text: A valid binding property info must be provided for "{}"; severity:error; range:9:28-9:30',
+        ]);
+      });
+    });
+  });
+  describe("brackets", () => {
+    describe("missing right curly bracket [brace]", () => {
+      it("case 01 [no diagnostic]", async () => {
+        const snippet = `
+        <Text text="{" id="test-id"></Text>`;
+        const result = await validateView(snippet);
+        expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
+          "kind: MissingBracket; text: Expect closing brace; severity:error; range:9:20-9:21",
+        ]);
+      });
+      it("case 02 [diagnostic [at least key with colon]", async () => {
+        const snippet = `
+        <Text text="{path: '' " id="test-id"></Text>`;
+        const result = await validateView(snippet);
+        expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
+          "kind: MissingBracket; text: Expect closing brace; severity:error; range:9:20-9:29",
+        ]);
+      });
+      it("case 03 [inside collection]", async () => {
+        const snippet = `
+        <Text text="{ parts: [{path: '' ] }" id="test-id"></Text>`;
+        const result = await validateView(snippet);
+        expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
+          "kind: MissingBracket; text: Expect closing brace; severity:error; range:9:30-9:39",
+        ]);
+      });
+    });
+    describe("missing right square bracket [bracket]", () => {
+      it("case 01", async () => {
+        const snippet = `
+        <Text text="{parts: ['' }" id="test-id"></Text>`;
+        const result = await validateView(snippet);
+        expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
+          "kind: MissingBracket; text: Expect closing bracket; severity:error; range:9:28-9:31",
+        ]);
+      });
+      it("case 02", async () => {
+        const snippet = `
+        <Text text="{parts: [{path: ''} }" id="test-id"></Text>`;
+        const result = await validateView(snippet);
+        expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
+          "kind: MissingBracket; text: Expect closing bracket; severity:error; range:9:28-9:39",
         ]);
       });
     });

--- a/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
+++ b/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
@@ -57,6 +57,12 @@ describe("property-binding-info-validator", () => {
     const result = await validateView(snippet);
     expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([]);
   });
+  it("do not check {} with unknown char", async () => {
+    const snippet = `
+    <Text text="{!}" id="test-id"></Text>`;
+    const result = await validateView(snippet);
+    expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([]);
+  });
   it("do not check {path} [at least a key with colon must exits]", async () => {
     const snippet = `
     <Text text="{path}" id="test-id"></Text>`;

--- a/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
+++ b/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
@@ -119,6 +119,14 @@ describe("property-binding-info-validator", () => {
       "kind: MissingColon; text: Expect colon; severity:error; range:9:18-9:22",
     ]);
   });
+  it("check missing key", async () => {
+    const snippet = `
+    <Text text="{ : {}, type: {}}" id="test-id"></Text>`;
+    const result = await validateView(snippet);
+    expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
+      "kind: MissingKey; text: Expect key; severity:error; range:9:18-9:19",
+    ]);
+  });
   it("check missing value", async () => {
     const snippet = `
     <Text text="{ path: }" id="test-id"></Text>`;
@@ -513,6 +521,10 @@ describe("property-binding-info-validator", () => {
     const result = await validateView(snippet);
     expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
       "kind: TooManyColons; text: Too many colon; severity:error; range:9:23-9:24",
+      "kind: MissingKey; text: Expect key; severity:error; range:9:23-9:24",
+      "kind: MissingKey; text: Expect key; severity:error; range:9:24-9:25",
+      "kind: MissingKey; text: Expect key; severity:error; range:9:25-9:26",
+      "kind: MissingKey; text: Expect key; severity:error; range:9:26-9:27",
     ]);
   });
   it("check too many object", async () => {

--- a/packages/binding/test/unit/utils/cursor.test.ts
+++ b/packages/binding/test/unit/utils/cursor.test.ts
@@ -137,6 +137,17 @@ describe("cursor", () => {
       });
       expect(element).toBeDefined();
     });
+    it("i. keyProperty:`<CURSOR>` [no spaces]", () => {
+      const snippet = `{keyProperty:<CURSOR>}`;
+      const { kind, type, element } = getCursorContextResult(
+        snippet
+      ) as ValueContext;
+      expect({ type, kind }).toStrictEqual({
+        type: "value",
+        kind: "value",
+      });
+      expect(element).toBeDefined();
+    });
   });
   describe("get key value context", () => {
     it("a. keyProperty: 'value-for-this-key'  `<CURSOR>` [spaces]", () => {

--- a/packages/binding/test/unit/utils/cursor.test.ts
+++ b/packages/binding/test/unit/utils/cursor.test.ts
@@ -1,10 +1,5 @@
 import { parseBinding } from "@ui5-language-assistant/binding-parser";
-import {
-  ColonContext,
-  KeyContext,
-  KeyValueContext,
-  ValueContext,
-} from "../../../src/types";
+import { KeyContext, KeyValueContext, ValueContext } from "../../../src/types";
 import { getCursorContext } from "../../../src/utils";
 const getData = (snippet: string) => {
   const param = {
@@ -120,86 +115,69 @@ describe("cursor", () => {
       });
       expect(element).toBeDefined();
     });
+    it("g. keyProperty `<CURSOR>` 'value-for-this-key' [missing colon]", () => {
+      const snippet = `{keyProperty <CURSOR> 'value-for-this-key'}`;
+      const { kind, type, element } = getCursorContextResult(
+        snippet
+      ) as ValueContext;
+      expect({ kind, type }).toStrictEqual({
+        type: "value",
+        kind: "value",
+      });
+      expect(element).toBeDefined();
+    });
+    it("h. keyProperty `<CURSOR>` [space(s)] [missing colon]", () => {
+      const snippet = `{keyProperty <CURSOR>}`;
+      const { kind, type, element } = getCursorContextResult(
+        snippet
+      ) as ValueContext;
+      expect({ kind, type }).toStrictEqual({
+        type: "value",
+        kind: "value",
+      });
+      expect(element).toBeDefined();
+    });
   });
   describe("get key value context", () => {
     it("a. keyProperty: 'value-for-this-key'  `<CURSOR>` [spaces]", () => {
       const snippet = `{ keyProperty: 'value-for-this-key'  <CURSOR> }`;
-      const { type, kind, element } = getCursorContextResult(
-        snippet
-      ) as KeyValueContext;
+      const { type, kind } = getCursorContextResult(snippet) as KeyValueContext;
       expect({ type, kind }).toStrictEqual({
         type: "key-value",
         kind: "properties-with-value-excluding-duplicate",
       });
-      expect(element).toBeDefined();
     });
     it("b. keyProperty: 'value-for-this-key', `<CURSOR>` [comma]", () => {
       const snippet = `{ keyProperty: 'value-for-this-key',  <CURSOR> }`;
-      const { type, kind, element } = getCursorContextResult(
-        snippet
-      ) as KeyValueContext;
+      const { type, kind } = getCursorContextResult(snippet) as KeyValueContext;
       expect({ type, kind }).toStrictEqual({
         type: "key-value",
         kind: "properties-with-value-excluding-duplicate",
       });
-      expect(element).toBeDefined();
     });
     it("c. `<CURSOR>` keyProperty: 'value-for-this-key'", () => {
       const snippet = `{<CURSOR> keyProperty: 'value-for-this-key'}`;
-      const { type, kind, element } = getCursorContextResult(
-        snippet
-      ) as KeyValueContext;
+      const { type, kind } = getCursorContextResult(snippet) as KeyValueContext;
       expect({ type, kind }).toStrictEqual({
         type: "key-value",
         kind: "properties-with-value-excluding-duplicate",
       });
-      expect(element).toBeDefined();
     });
     it("d. `keyProperty: 'value-for-this-key',`<CURSOR>`, [between comma]", () => {
       const snippet = `{keyProperty: 'value-for-this-key',<CURSOR>, }`;
-      const { type, kind, element } = getCursorContextResult(
-        snippet
-      ) as KeyValueContext;
+      const { type, kind } = getCursorContextResult(snippet) as KeyValueContext;
       expect({ type, kind }).toStrictEqual({
         type: "key-value",
         kind: "properties-with-value-excluding-duplicate",
       });
-      expect(element).toBeDefined();
     });
     it("e. `keyProperty: 'value-for-this-key',`<CURSOR>`, [between comma - spaces]", () => {
       const snippet = `{keyProperty: 'value-for-this-key', <CURSOR>, }`;
-      const { type, kind, element } = getCursorContextResult(
-        snippet
-      ) as KeyValueContext;
+      const { type, kind } = getCursorContextResult(snippet) as KeyValueContext;
       expect({ type, kind }).toStrictEqual({
         type: "key-value",
         kind: "properties-with-value-excluding-duplicate",
       });
-      expect(element).toBeDefined();
-    });
-  });
-  describe("get colon context", () => {
-    it("a. keyProperty `<CURSOR>` 'value-for-this-key'", () => {
-      const snippet = `{keyProperty <CURSOR> 'value-for-this-key'}`;
-      const { kind, type, element } = getCursorContextResult(
-        snippet
-      ) as ColonContext;
-      expect({ kind, type }).toStrictEqual({
-        type: "colon",
-        kind: "colon",
-      });
-      expect(element).toBeDefined();
-    });
-    it("b. keyProperty `<CURSOR>` [space(s)]", () => {
-      const snippet = `{keyProperty <CURSOR>}`;
-      const { kind, type, element } = getCursorContextResult(
-        snippet
-      ) as ColonContext;
-      expect({ kind, type }).toStrictEqual({
-        type: "colon",
-        kind: "colon",
-      });
-      expect(element).toBeDefined();
     });
   });
   it("parts", () => {


### PR DESCRIPTION
This PR address following points:
* No diagnostic for empty bracket with unknown char e.g `<Text text="{!!!}" id="test-id"/>`
* No duplicate or wrong code completion for multiple binding e.g `<Text text="some text and {} some here {parts: [|]}" id="test-id"/>`
* Add diagnostic for missing key e.g `<Text text="{:'', formatter: '.methodName'}" id="test-id"/>`
* Add diagnostic for missing bracket eg. `{path: ''` , `parts: [''` or `parts: [{path: '']` 
* Correct completion for collection
a. `<Text text="{ parts: |[{}] }" id="test-id"/>` - no completion item(s)
b. `<Text text="{ parts: [{}]| }" id="test-id"/>` - no completion item(s)
c. `<Text text="{ parts: [|{}] }" id="test-id"/>`
d. `<Text text="{ parts: [{}|] }" id="test-id"/>`
e. `<Text text="{ parts: [''|] }" id="test-id"/>`
f. `<Text text="{ parts: [|''] }" id="test-id"/>`
g. `<Text text="{ parts: ['|'] }" id="test-id"/>` - no completion item(s)

**Note** `|` represent cursor position

Related issue: https://github.com/SAP/ui5-language-assistant/issues/563

Todo
* code completion for missing key e.g `{:''}`