### PR TITLE
fix: remove choice

### DIFF
--- a/.changeset/empty-balloons-repeat.md
+++ b/.changeset/empty-balloons-repeat.md
@@ -1,0 +1,7 @@
+---
+"@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext": patch
+"vscode-ui5-language-assistant": patch
+"@ui5-language-assistant/binding": patch
+---
+
+fix: remove choice from completion items

--- a/packages/binding/src/services/completion/index.ts
+++ b/packages/binding/src/services/completion/index.ts
@@ -10,6 +10,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 
 import { attributeValueProviders } from "./providers";
 import { BindContext } from "../../types";
+import { getLogger } from "../../utils";
 
 export function getCompletionItems(opts: {
   context: Context;
@@ -38,8 +39,12 @@ export function getCompletionItems(opts: {
         attributeValue: attributeValueProviders,
       },
     });
+    getLogger().trace("computed completion items", {
+      suggestions,
+    });
     return suggestions;
   } catch (error) {
+    getLogger().debug("getCompletionItems failed:", error);
     return [];
   }
 }

--- a/packages/binding/src/services/completion/providers/create-all-supported-elements.ts
+++ b/packages/binding/src/services/completion/providers/create-all-supported-elements.ts
@@ -16,16 +16,7 @@ export const createAllSupportedElements = (
 ): CompletionItem[] => {
   return propertyBindingInfoElements.map((item) => {
     const type = typesToValue(item.type, context, 0);
-    let text = "";
-    if (type.length === 1) {
-      text = `${item.name}: ${type[0]}`;
-    } else {
-      let choice = type.join(",");
-      // choice does not support tab stop
-      choice = choice.replace(/\$\d+/g, "");
-      choice = "${1|" + choice + "|}$0";
-      text = `${item.name}: ${choice}`;
-    }
+    const text = `${item.name}: ${type.length === 1 ? type[0] : "$0"}`;
     const documentation = getDocumentation(item);
     return {
       label: item.name,

--- a/packages/binding/src/services/completion/providers/create-initial-snippet.ts
+++ b/packages/binding/src/services/completion/providers/create-initial-snippet.ts
@@ -4,12 +4,9 @@ import {
   InsertTextFormat,
 } from "vscode-languageserver-types";
 
-import { propertyBindingInfoElements } from "../../../definition/definition";
-
 export const createInitialSnippet = (): CompletionItem[] => {
   const completionItems: CompletionItem[] = [];
-  const names = propertyBindingInfoElements.map((item) => item.name);
-  let text = "{ ${1|" + names.join(",") + "|}: $0 }";
+  let text = "{ $0 }";
   completionItems.push({
     label: "{ }",
     insertTextFormat: InsertTextFormat.Snippet,

--- a/packages/binding/src/services/completion/providers/create-key-value.ts
+++ b/packages/binding/src/services/completion/providers/create-key-value.ts
@@ -28,16 +28,7 @@ export const createKeyValue = (
     })
     .map((item) => {
       const type = typesToValue(item.type, context, 0);
-      let text = "";
-      if (type.length === 1) {
-        text = `${item.name}: ${type[0]}`;
-      } else {
-        let choice = type.join(",");
-        // choice does not support tab stop
-        choice = choice.replace(/\$\d+/g, "");
-        choice = "${1|" + choice + "|}$0";
-        text = `${item.name}: ${choice}`;
-      }
+      const text = `${item.name}: ${type.length === 1 ? type[0] : "$0"}`;
       const documentation = getDocumentation(item);
       return {
         label: item.name,

--- a/packages/binding/src/services/diagnostics/validators/property-binding-info-validator.ts
+++ b/packages/binding/src/services/diagnostics/validators/property-binding-info-validator.ts
@@ -5,6 +5,7 @@ import { BindingIssue } from "../../../types";
 import { BINDING_ISSUE_TYPE } from "../../../constant";
 import {
   extractBindingExpression,
+  getLogger,
   isBindingExpression,
   isPropertyBindingInfo,
 } from "../../../utils";
@@ -84,9 +85,10 @@ export function validatePropertyBindingInfo(
         }
       }
     }
-
+    getLogger().trace("computed diagnostics", { diagnostics: issues });
     return issues;
   } catch (error) {
+    getLogger().debug("validatePropertyBindingInfo failed:", error);
     return issues;
   }
 }

--- a/packages/binding/src/utils/index.ts
+++ b/packages/binding/src/utils/index.ts
@@ -13,3 +13,5 @@ export {
 } from "./element";
 
 export { getCursorContext } from "./cursor";
+
+export { getLogger } from "./logger";

--- a/packages/binding/src/utils/logger.ts
+++ b/packages/binding/src/utils/logger.ts
@@ -1,0 +1,24 @@
+import {
+  getLogger as logger,
+  ILogger,
+} from "@ui5-language-assistant/logic-utils";
+
+const getPackageName = (): string => {
+  let meta: { name: string };
+  try {
+    meta = require("../../package.json");
+  } catch (e) {
+    meta = require("../../../package.json");
+  }
+
+  if (!meta) {
+    return "";
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- Using `require` for .json file as this gets bundled with webpack correctly.
+  return meta.name;
+};
+
+export const getLogger = (): ILogger => {
+  const name = getPackageName();
+  return logger(name);
+};

--- a/packages/binding/test/unit/services/completion/__snapshots__/index.test.ts.snap
+++ b/packages/binding/test/unit/services/completion/__snapshots__/index.test.ts.snap
@@ -11,21 +11,21 @@ Array [
   "label: model; text: model: '$0'; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Name of the model to bind against; when undefined or omitted, the default model is used 
 
  **Visibility:** Public",
-  "label: suspended; text: suspended: \${1|true,false|}$0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Whether the binding should be suspended initially 
+  "label: suspended; text: suspended: $0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Whether the binding should be suspended initially 
 
  **Visibility:** Public",
   "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Function to convert model data into a property value 
 
  **Visibility:** Public",
-  "label: useRawValues; text: useRawValues: \${1|true,false|}$0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Whether the parameters to the formatter function should be passed as raw values. In this case the specified types for the binding parts are not used and the values are not formatted.
+  "label: useRawValues; text: useRawValues: $0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Whether the parameters to the formatter function should be passed as raw values. In this case the specified types for the binding parts are not used and the values are not formatted.
 **Note**: use this flag only when using multiple bindings. If you use only one binding and want raw values then simply don't specify a type for that binding 
 
  **Visibility:** Public",
-  "label: useInternalValues; text: useInternalValues: \${1|true,false|}$0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Whether the parameters to the formatter function should be passed as the related JavaScript primitive values. In this case the values of the model are parsed by the model format of the specified types from the binding parts.
+  "label: useInternalValues; text: useInternalValues: $0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Whether the parameters to the formatter function should be passed as the related JavaScript primitive values. In this case the values of the model are parsed by the model format of the specified types from the binding parts.
 **Note**: use this flag only when using multiple bindings. 
 
  **Visibility:** Public",
-  "label: type; text: type: \${1|{},''|}$0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** A type object or the name of a type class to create such a type object; the type will be used for converting model data to a property value (aka \\"formatting\\") and vice versa (in binding mode TwoWay, aka \\"parsing\\") 
+  "label: type; text: type: $0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** A type object or the name of a type class to create such a type object; the type will be used for converting model data to a property value (aka \\"formatting\\") and vice versa (in binding mode TwoWay, aka \\"parsing\\") 
 
  **Visibility:** Public",
   "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Target type to be used by the type when formatting model data, for example \\"boolean\\" or \\"string\\" or \\"any\\"; defaults to the property's type 
@@ -46,7 +46,7 @@ Array [
   "label: events; text: events: {$0}; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Map of event handler functions keyed by the name of the binding events that they should be attached to 
 
  **Visibility:** Public",
-  "label: parts; text: parts: \${1|[{}],['']|}$0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Array of binding info objects for the parts of a composite binding; the structure of each binding info is the same as described for the oBindingInfo as a whole.
+  "label: parts; text: parts: $0; kind:15; commit:undefined; sort:; documentation: kind:markdown,value:**Description:** Array of binding info objects for the parts of a composite binding; the structure of each binding info is the same as described for the oBindingInfo as a whole.
 If a part is not specified as a binding info object but as a simple string, a binding info object will be created with that string as path. The string may start with a model name prefix (see property path).
 **Note**: recursive composite bindings are currently not supported. Therefore, a part must not contain a parts property 
 

--- a/packages/binding/test/unit/services/completion/index.test.ts
+++ b/packages/binding/test/unit/services/completion/index.test.ts
@@ -108,7 +108,7 @@ describe("index", () => {
       expect(
         result.map((item) => completionItemToSnapshot(item))
       ).toStrictEqual([
-        "label: { }; text: { ${1|path,value,model,suspended,formatter,useRawValues,useInternalValues,type,targetType,formatOptions,constraints,mode,parameters,events,parts|}: $0 }; kind:15; commit:undefined; sort:",
+        "label: { }; text: { $0 }; kind:15; commit:undefined; sort:",
         "label: {= }; text: {= $0 }; kind:15; commit:undefined; sort:",
         "label: {:= }; text: {:= $0 }; kind:15; commit:undefined; sort:",
       ]);
@@ -120,7 +120,7 @@ describe("index", () => {
       expect(
         result.map((item) => completionItemToSnapshot(item))
       ).toStrictEqual([
-        "label: { }; text: { ${1|path,value,model,suspended,formatter,useRawValues,useInternalValues,type,targetType,formatOptions,constraints,mode,parameters,events,parts|}: $0 }; kind:15; commit:undefined; sort:",
+        "label: { }; text: { $0 }; kind:15; commit:undefined; sort:",
         "label: {= }; text: {= $0 }; kind:15; commit:undefined; sort:",
         "label: {:= }; text: {:= $0 }; kind:15; commit:undefined; sort:",
       ]);
@@ -365,11 +365,11 @@ describe("index", () => {
           "label: path; text: path: '$0'; kind:15; commit:undefined; sort:",
           "label: value; text: value: '$0'; kind:15; commit:undefined; sort:",
           "label: model; text: model: '$0'; kind:15; commit:undefined; sort:",
-          "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: suspended; text: suspended: $0; kind:15; commit:undefined; sort:",
           "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:",
-          "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: type; text: type: ${1|{},''|}$0; kind:15; commit:undefined; sort:",
+          "label: useRawValues; text: useRawValues: $0; kind:15; commit:undefined; sort:",
+          "label: useInternalValues; text: useInternalValues: $0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: $0; kind:15; commit:undefined; sort:",
           "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:",
           "label: formatOptions; text: formatOptions: {$0}; kind:15; commit:undefined; sort:",
           "label: constraints; text: constraints: {$0}; kind:15; commit:undefined; sort:",
@@ -457,18 +457,18 @@ describe("index", () => {
         ).toStrictEqual([
           "label: value; text: value: '$0'; kind:15; commit:undefined; sort:",
           "label: model; text: model: '$0'; kind:15; commit:undefined; sort:",
-          "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: suspended; text: suspended: $0; kind:15; commit:undefined; sort:",
           "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:",
-          "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: type; text: type: ${1|{},''|}$0; kind:15; commit:undefined; sort:",
+          "label: useRawValues; text: useRawValues: $0; kind:15; commit:undefined; sort:",
+          "label: useInternalValues; text: useInternalValues: $0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: $0; kind:15; commit:undefined; sort:",
           "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:",
           "label: formatOptions; text: formatOptions: {$0}; kind:15; commit:undefined; sort:",
           "label: constraints; text: constraints: {$0}; kind:15; commit:undefined; sort:",
           "label: mode; text: mode: '$0'; kind:15; commit:undefined; sort:",
           "label: parameters; text: parameters: {$0}; kind:15; commit:undefined; sort:",
           "label: events; text: events: {$0}; kind:15; commit:undefined; sort:",
-          "label: parts; text: parts: ${1|[{}],['']|}$0; kind:15; commit:undefined; sort:",
+          "label: parts; text: parts: $0; kind:15; commit:undefined; sort:",
         ]);
       });
       it("b. keyProperty: 'value-for-this-key', `<CURSOR>` [comma]", async function () {
@@ -480,18 +480,18 @@ describe("index", () => {
         ).toStrictEqual([
           "label: value; text: value: '$0'; kind:15; commit:undefined; sort:",
           "label: model; text: model: '$0'; kind:15; commit:undefined; sort:",
-          "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: suspended; text: suspended: $0; kind:15; commit:undefined; sort:",
           "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:",
-          "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: type; text: type: ${1|{},''|}$0; kind:15; commit:undefined; sort:",
+          "label: useRawValues; text: useRawValues: $0; kind:15; commit:undefined; sort:",
+          "label: useInternalValues; text: useInternalValues: $0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: $0; kind:15; commit:undefined; sort:",
           "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:",
           "label: formatOptions; text: formatOptions: {$0}; kind:15; commit:undefined; sort:",
           "label: constraints; text: constraints: {$0}; kind:15; commit:undefined; sort:",
           "label: mode; text: mode: '$0'; kind:15; commit:undefined; sort:",
           "label: parameters; text: parameters: {$0}; kind:15; commit:undefined; sort:",
           "label: events; text: events: {$0}; kind:15; commit:undefined; sort:",
-          "label: parts; text: parts: ${1|[{}],['']|}$0; kind:15; commit:undefined; sort:",
+          "label: parts; text: parts: $0; kind:15; commit:undefined; sort:",
         ]);
       });
       it("c. `<CURSOR>` keyProperty: 'value-for-this-key'", async function () {
@@ -503,18 +503,18 @@ describe("index", () => {
         ).toStrictEqual([
           "label: value; text: value: '$0'; kind:15; commit:undefined; sort:",
           "label: model; text: model: '$0'; kind:15; commit:undefined; sort:",
-          "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: suspended; text: suspended: $0; kind:15; commit:undefined; sort:",
           "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:",
-          "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: type; text: type: ${1|{},''|}$0; kind:15; commit:undefined; sort:",
+          "label: useRawValues; text: useRawValues: $0; kind:15; commit:undefined; sort:",
+          "label: useInternalValues; text: useInternalValues: $0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: $0; kind:15; commit:undefined; sort:",
           "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:",
           "label: formatOptions; text: formatOptions: {$0}; kind:15; commit:undefined; sort:",
           "label: constraints; text: constraints: {$0}; kind:15; commit:undefined; sort:",
           "label: mode; text: mode: '$0'; kind:15; commit:undefined; sort:",
           "label: parameters; text: parameters: {$0}; kind:15; commit:undefined; sort:",
           "label: events; text: events: {$0}; kind:15; commit:undefined; sort:",
-          "label: parts; text: parts: ${1|[{}],['']|}$0; kind:15; commit:undefined; sort:",
+          "label: parts; text: parts: $0; kind:15; commit:undefined; sort:",
         ]);
       });
       it("d. keyProperty: 'value-for-this-key',`<CURSOR>`, [between comma]", async function () {
@@ -526,18 +526,18 @@ describe("index", () => {
         ).toStrictEqual([
           "label: value; text: value: '$0'; kind:15; commit:undefined; sort:",
           "label: model; text: model: '$0'; kind:15; commit:undefined; sort:",
-          "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: suspended; text: suspended: $0; kind:15; commit:undefined; sort:",
           "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:",
-          "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: type; text: type: ${1|{},''|}$0; kind:15; commit:undefined; sort:",
+          "label: useRawValues; text: useRawValues: $0; kind:15; commit:undefined; sort:",
+          "label: useInternalValues; text: useInternalValues: $0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: $0; kind:15; commit:undefined; sort:",
           "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:",
           "label: formatOptions; text: formatOptions: {$0}; kind:15; commit:undefined; sort:",
           "label: constraints; text: constraints: {$0}; kind:15; commit:undefined; sort:",
           "label: mode; text: mode: '$0'; kind:15; commit:undefined; sort:",
           "label: parameters; text: parameters: {$0}; kind:15; commit:undefined; sort:",
           "label: events; text: events: {$0}; kind:15; commit:undefined; sort:",
-          "label: parts; text: parts: ${1|[{}],['']|}$0; kind:15; commit:undefined; sort:",
+          "label: parts; text: parts: $0; kind:15; commit:undefined; sort:",
         ]);
       });
     });
@@ -572,18 +572,18 @@ describe("index", () => {
           "label: path; text: path: '$0'; kind:15; commit:undefined; sort:",
           "label: value; text: value: '$0'; kind:15; commit:undefined; sort:",
           "label: model; text: model: '$0'; kind:15; commit:undefined; sort:",
-          "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: suspended; text: suspended: $0; kind:15; commit:undefined; sort:",
           "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:",
-          "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: type; text: type: ${1|{},''|}$0; kind:15; commit:undefined; sort:",
+          "label: useRawValues; text: useRawValues: $0; kind:15; commit:undefined; sort:",
+          "label: useInternalValues; text: useInternalValues: $0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: $0; kind:15; commit:undefined; sort:",
           "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:",
           "label: formatOptions; text: formatOptions: {$0}; kind:15; commit:undefined; sort:",
           "label: constraints; text: constraints: {$0}; kind:15; commit:undefined; sort:",
           "label: mode; text: mode: '$0'; kind:15; commit:undefined; sort:",
           "label: parameters; text: parameters: {$0}; kind:15; commit:undefined; sort:",
           "label: events; text: events: {$0}; kind:15; commit:undefined; sort:",
-          "label: parts; text: parts: ${1|[{}],['']|}$0; kind:15; commit:undefined; sort:",
+          "label: parts; text: parts: $0; kind:15; commit:undefined; sort:",
         ]);
       });
       it("no double CC items for two or more empty binding [consider consumed properties]", async function () {
@@ -595,18 +595,18 @@ describe("index", () => {
         ).toStrictEqual([
           "label: value; text: value: '$0'; kind:15; commit:undefined; sort:",
           "label: model; text: model: '$0'; kind:15; commit:undefined; sort:",
-          "label: suspended; text: suspended: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
+          "label: suspended; text: suspended: $0; kind:15; commit:undefined; sort:",
           "label: formatter; text: formatter: '$0'; kind:15; commit:undefined; sort:",
-          "label: useRawValues; text: useRawValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: useInternalValues; text: useInternalValues: ${1|true,false|}$0; kind:15; commit:undefined; sort:",
-          "label: type; text: type: ${1|{},''|}$0; kind:15; commit:undefined; sort:",
+          "label: useRawValues; text: useRawValues: $0; kind:15; commit:undefined; sort:",
+          "label: useInternalValues; text: useInternalValues: $0; kind:15; commit:undefined; sort:",
+          "label: type; text: type: $0; kind:15; commit:undefined; sort:",
           "label: targetType; text: targetType: '$0'; kind:15; commit:undefined; sort:",
           "label: formatOptions; text: formatOptions: {$0}; kind:15; commit:undefined; sort:",
           "label: constraints; text: constraints: {$0}; kind:15; commit:undefined; sort:",
           "label: mode; text: mode: '$0'; kind:15; commit:undefined; sort:",
           "label: parameters; text: parameters: {$0}; kind:15; commit:undefined; sort:",
           "label: events; text: events: {$0}; kind:15; commit:undefined; sort:",
-          "label: parts; text: parts: ${1|[{}],['']|}$0; kind:15; commit:undefined; sort:",
+          "label: parts; text: parts: $0; kind:15; commit:undefined; sort:",
         ]);
       });
       it("provides no CC for wrong context", async function () {


### PR DESCRIPTION
Background:
VSCode-Insider (version: 1.80.0-insider (Universal)) shuts down completely completion item request if there is a completion item with choices and user select this item. Subsequent completion item request will not work. 

Choices are just fine to keep, but there is one another usability  issue with them. Choice does not support tab stop. To get around with VSCode issue and choice restriction, choice option is removed from completion item for property binding info.

