### PR TITLE
fix: unjustified errors for property binding info

### DIFF
--- a/.changeset/shiny-maps-guess.md
+++ b/.changeset/shiny-maps-guess.md
@@ -1,0 +1,8 @@
+---
+"@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext": patch
+"vscode-ui5-language-assistant": patch
+"@ui5-language-assistant/binding-parser": patch
+"@ui5-language-assistant/binding": patch
+---
+
+fix unjustified errors for property binding info

--- a/packages/binding-parser/src/api.ts
+++ b/packages/binding-parser/src/api.ts
@@ -7,7 +7,11 @@ export {
   isBeforeAdjacentRange,
   positionContained,
   rangeContained,
-} from "./utils/position";
+  isBindingExpression,
+  isMetadataPath,
+  isModel,
+  isPropertyBindingInfo,
+} from "./utils";
 
 import {
   Value,

--- a/packages/binding-parser/src/lexer/token.ts
+++ b/packages/binding-parser/src/lexer/token.ts
@@ -25,7 +25,7 @@ const whiteSpace = createToken({
 const specialChars = createToken({
   name: SPECIAL_CHARS,
   pattern:
-    /(?:#|!|"|\$|%|&|'|\(|\)|\*|\+|-|\.|\/|;|<|=|>|\?|@|\\|\^|_|`|~|\||)+/,
+    /(?:#|&gt;|&#47;|&#x2F;|!|"|\$|%|&|'|\(|\)|\*|\+|-|\.|\/|;|<|=|>|\?|@|\\|\^|_|`|~|\||)+/,
 });
 
 const leftCurly = createToken({

--- a/packages/binding-parser/src/types/binding-parser.ts
+++ b/packages/binding-parser/src/types/binding-parser.ts
@@ -136,14 +136,15 @@ export interface Template {
   spaces: WhiteSpaces[];
 }
 
+export interface ParseResultErrors {
+  lexer: LexerError[];
+  parse: ParseError[];
+}
 export interface ParseResult {
   cst: CstNode;
   ast: Template;
   tokens: IToken[];
-  errors: {
-    lexer: LexerError[];
-    parse: ParseError[];
-  };
+  errors: ParseResultErrors;
 }
 
 export interface CreateToken<T = TokenType> {

--- a/packages/binding-parser/src/utils/expression.ts
+++ b/packages/binding-parser/src/utils/expression.ts
@@ -1,0 +1,139 @@
+import type {
+  ParseResultErrors,
+  StructureValue,
+} from "../types/binding-parser";
+import { isAfterAdjacentRange, isBeforeAdjacentRange } from "./position";
+
+/**
+ * Syntax of a binding expression can be represented by `{=expression}` or `{:=expression}`
+ * If an input text starts with either `{=` or `{:=`, input text is considered as binding expression
+ */
+export const isBindingExpression = (input: string): boolean => {
+  input = input.trim();
+  return /^{(=|:=)/.test(input);
+};
+
+/**
+ * Check model
+ *
+ * It is considered as model when it contains `>` or `>/` after first key e.g oData> or oData>/...
+ */
+export const isModel = (
+  binding: StructureValue,
+  errors?: ParseResultErrors
+): boolean => {
+  if (!errors) {
+    return false;
+  }
+  const modelSign = errors.lexer.find(
+    (i) => i.type === "special-chars" && [">", ">/"].includes(i.text)
+  );
+  if (!modelSign) {
+    return false;
+  }
+  // check model should appears after first key
+  if (isBeforeAdjacentRange(binding.elements[0]?.key?.range, modelSign.range)) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Check metadata path
+ *
+ * It is considered metadata path when it is `/` as separator and
+ *
+ * a. is before first key e.g /key
+ *
+ * b. is after first key e.g. key/
+ */
+export const isMetadataPath = (
+  binding: StructureValue,
+  errors?: ParseResultErrors
+): boolean => {
+  if (!errors) {
+    return false;
+  }
+  const metadataSeparator = errors.lexer.find(
+    (i) => i.type === "special-chars" && i.text.startsWith("/")
+  );
+  if (!metadataSeparator) {
+    return false;
+  }
+  // check metadata separator is before first key e.g /key
+  if (
+    binding.elements[0]?.key?.range.start &&
+    isBeforeAdjacentRange(
+      metadataSeparator.range,
+      binding.elements[0].key.range
+    )
+  ) {
+    return true;
+  }
+  // check metadata separator is after first key e.g. key/
+  if (
+    isAfterAdjacentRange(
+      metadataSeparator.range,
+      binding.elements[0]?.key?.range
+    )
+  ) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * An input is considered property binding syntax when
+ *
+ * a. is empty curly bracket e.g  `{}` or `{   }`
+ *
+ * b. has starting or closing curly bracket and key property with colon e.g `{anyKey: }` or `{"anyKey":}` or `{'anyKey':}`
+ *
+ * c. empty string [for initial code completion snippet]
+ *
+ * d. is not model e.g {i18n>...} or {oData>...}
+ *
+ * e. is not OData path e.g {/path/to/...} or {path/to/...}
+ */
+export const isPropertyBindingInfo = (
+  input: string,
+  binding?: StructureValue,
+  errors?: ParseResultErrors
+): boolean => {
+  // check empty string
+  if (input.trim().length === 0) {
+    return true;
+  }
+
+  if (!binding) {
+    return false;
+  }
+
+  // check if model
+  if (isModel(binding, errors)) {
+    return false;
+  }
+
+  // check if metadata path
+  if (isMetadataPath(binding, errors)) {
+    return false;
+  }
+
+  if (
+    binding.leftCurly &&
+    binding.leftCurly.text &&
+    binding.elements.length === 0
+  ) {
+    // check empty curly brackets
+    return true;
+  }
+  // check it has at least one key with colon
+  const result = binding.elements.find(
+    /* istanbul ignore next */
+    (item) => item.key?.text && item.colon?.text
+  );
+  if (result && binding.leftCurly && binding.leftCurly.text) {
+    return true;
+  }
+  return false;
+};

--- a/packages/binding-parser/src/utils/expression.ts
+++ b/packages/binding-parser/src/utils/expression.ts
@@ -16,7 +16,7 @@ export const isBindingExpression = (input: string): boolean => {
 /**
  * Check model
  *
- * It is considered as model when it contains `>` or `>/` after first key e.g oData> or oData>/...
+ * It is considered as model when it starts with `>` after first key without any quotes e.g oData> or oData>/...
  */
 export const isModel = (
   binding: StructureValue,
@@ -26,13 +26,16 @@ export const isModel = (
     return false;
   }
   const modelSign = errors.lexer.find(
-    (i) => i.type === "special-chars" && [">", ">/"].includes(i.text)
+    (i) => i.type === "special-chars" && i.text.startsWith(">")
   );
   if (!modelSign) {
     return false;
   }
-  // check model should appears after first key
-  if (isBeforeAdjacentRange(binding.elements[0]?.key?.range, modelSign.range)) {
+  // check model should appears after first key without quotes
+  if (
+    binding.elements[0]?.key?.originalText === binding.elements[0]?.key?.text &&
+    isBeforeAdjacentRange(binding.elements[0]?.key?.range, modelSign.range)
+  ) {
     return true;
   }
   return false;

--- a/packages/binding-parser/src/utils/expression.ts
+++ b/packages/binding-parser/src/utils/expression.ts
@@ -16,7 +16,7 @@ export const isBindingExpression = (input: string): boolean => {
 /**
  * Check model
  *
- * It is considered as model when it starts with `>` after first key without any quotes e.g oData> or oData>/...
+ * It is considered as model when it starts with `>` or its HTML equivalent after first key without any quotes e.g oData> or oData>/...
  */
 export const isModel = (
   binding: StructureValue,
@@ -26,7 +26,9 @@ export const isModel = (
     return false;
   }
   const modelSign = errors.lexer.find(
-    (i) => i.type === "special-chars" && i.text.startsWith(">")
+    (i) =>
+      i.type === "special-chars" &&
+      (i.text.startsWith(">") || i.text.startsWith("&gt;"))
   );
   if (!modelSign) {
     return false;
@@ -44,7 +46,7 @@ export const isModel = (
 /**
  * Check metadata path
  *
- * It is considered metadata path when it is `/` as separator and
+ * It is considered metadata path when it is `/` or its HTML equivalent as separator and
  *
  * a. is before first key e.g /key
  *
@@ -58,7 +60,11 @@ export const isMetadataPath = (
     return false;
   }
   const metadataSeparator = errors.lexer.find(
-    (i) => i.type === "special-chars" && i.text.startsWith("/")
+    (i) =>
+      i.type === "special-chars" &&
+      (i.text.startsWith("/") ||
+        i.text.startsWith("&#47;") ||
+        i.text.startsWith("&#x2F;"))
   );
   if (!metadataSeparator) {
     return false;

--- a/packages/binding-parser/src/utils/index.ts
+++ b/packages/binding-parser/src/utils/index.ts
@@ -1,0 +1,14 @@
+export {
+  isAfterAdjacentRange,
+  isBefore,
+  isBeforeAdjacentRange,
+  positionContained,
+  rangeContained,
+} from "./position";
+
+export {
+  isBindingExpression,
+  isMetadataPath,
+  isModel,
+  isPropertyBindingInfo,
+} from "./expression";

--- a/packages/binding-parser/test/unit/utils/expression.test.ts
+++ b/packages/binding-parser/test/unit/utils/expression.test.ts
@@ -108,6 +108,26 @@ describe("expression", () => {
       const { ast, errors } = parseBinding(input);
       expect(isModel(ast.bindings[0], errors)).toBe(false);
     });
+    it("return false if key is with single quote", () => {
+      const input = "{'path'>: ''}";
+      const { ast, errors } = parseBinding(input);
+      expect(isModel(ast.bindings[0], errors)).toBe(false);
+    });
+    it("return false if key is with double quotes", () => {
+      const input = '{"path">: ""}';
+      const { ast, errors } = parseBinding(input);
+      expect(isModel(ast.bindings[0], errors)).toBe(false);
+    });
+    it("return false if key is with single quote [HTML equivalent]", () => {
+      const input = "{&apos;path&apos;>: ''}";
+      const { ast, errors } = parseBinding(input);
+      expect(isModel(ast.bindings[0], errors)).toBe(false);
+    });
+    it("return false if key is with double quotes [HTML equivalent]", () => {
+      const input = "{&quot;path&quot;>: ''}";
+      const { ast, errors } = parseBinding(input);
+      expect(isModel(ast.bindings[0], errors)).toBe(false);
+    });
   });
   describe("isMetadataPath", () => {
     it("return false if errors is undefined", () => {

--- a/packages/binding-parser/test/unit/utils/expression.test.ts
+++ b/packages/binding-parser/test/unit/utils/expression.test.ts
@@ -1,0 +1,136 @@
+import { parseBinding } from "../../../src/parser";
+import {
+  isBindingExpression,
+  isMetadataPath,
+  isModel,
+  isPropertyBindingInfo,
+} from "../../../src/utils";
+
+describe("expression", () => {
+  describe("isBindingExpression", () => {
+    it("check binding expression {=", () => {
+      const result = isBindingExpression("{=");
+      expect(result).toBeTrue();
+    });
+    it("check  binding expression {:=", () => {
+      const result = isBindingExpression("{:=");
+      expect(result).toBeTrue();
+    });
+    it("check other false cases", () => {
+      const result = isBindingExpression("{");
+      expect(result).toBeFalse();
+    });
+  });
+  describe("isPropertyBindingInfo", () => {
+    it("empty string", () => {
+      const input = "  ";
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeTrue();
+    });
+    it("string value", () => {
+      const input = "40";
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeFalse();
+    });
+    it("empty curly bracket without space", () => {
+      const input = "{}";
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeTrue();
+    });
+    it("empty curly bracket with space", () => {
+      const input = "{   }";
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeTrue();
+    });
+    it("key with colone [true]", () => {
+      const input = ' {path: "some/path"}';
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeTrue();
+    });
+    it("key with colone any where [true]", () => {
+      const input = ' {path "some/path", thisKey: {}}';
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeTrue();
+    });
+    it("missing colon [false]", () => {
+      const input = '{path "some/path"}';
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeFalse();
+    });
+    it("contains > after first key [false]", () => {
+      const input = "{i18n>myTestModel}";
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeFalse();
+    });
+    it("contains / before first key [false]", () => {
+      const input = "{/oData/path/to/some/dynamic/value}";
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeFalse();
+    });
+    it("contains / after first key [false]", () => {
+      const input = "{/oData/path/to/some/dynamic/value}";
+      const { ast, errors } = parseBinding(input);
+      const result = isPropertyBindingInfo(input, ast.bindings[0], errors);
+      expect(result).toBeFalse();
+    });
+  });
+
+  describe("isModel", () => {
+    it("return false if errors is undefined", () => {
+      const input = "{path: 'acceptable'}";
+      const { ast } = parseBinding(input);
+      expect(isModel(ast.bindings[0])).toBe(false);
+    });
+
+    it("return true if model sign appears after first key", () => {
+      const input = "{oData>/path/to/a/value}";
+      const { ast, errors } = parseBinding(input);
+      expect(isModel(ast.bindings[0], errors)).toBe(true);
+    });
+
+    it("return false if model sign does not appear after first key", () => {
+      const input = "{i18n >}"; // space is not allowed
+      const { ast, errors } = parseBinding(input);
+      expect(isModel(ast.bindings[0], errors)).toBe(false);
+    });
+
+    it("return false if model sign is not found", () => {
+      const input = "{path: 'acceptable'}";
+      const { ast, errors } = parseBinding(input);
+      expect(isModel(ast.bindings[0], errors)).toBe(false);
+    });
+  });
+  describe("isMetadataPath", () => {
+    it("return false if errors is undefined", () => {
+      const input = "{/path/to/a/value}'}";
+      const { ast } = parseBinding(input);
+      expect(isMetadataPath(ast.bindings[0])).toBe(false);
+    });
+    it("return false if there is no metadata separator", () => {
+      const input = "{path: 'acceptable'}";
+      const { ast, errors } = parseBinding(input);
+      expect(isMetadataPath(ast.bindings[0], errors)).toBe(false);
+    });
+
+    it("return true if the metadata separator is before adjacent first key", () => {
+      const input = "{/path/to/a/value}";
+      const { ast, errors } = parseBinding(input);
+      expect(isMetadataPath(ast.bindings[0], errors)).toBe(true);
+    });
+
+    it("return true if the metadata separator is after adjacent first key", () => {
+      const input = "{path/to/a/value}";
+      const { ast, errors } = parseBinding(input);
+      expect(isMetadataPath(ast.bindings[0], errors)).toBe(true);
+    });
+  });
+});

--- a/packages/binding-parser/test/unit/utils/expression.test.ts
+++ b/packages/binding-parser/test/unit/utils/expression.test.ts
@@ -96,6 +96,11 @@ describe("expression", () => {
       const { ast, errors } = parseBinding(input);
       expect(isModel(ast.bindings[0], errors)).toBe(true);
     });
+    it("return true if model sign as HTML equivalent appears after first key", () => {
+      const input = "{oData&gt;/path/to/a/value}";
+      const { ast, errors } = parseBinding(input);
+      expect(isModel(ast.bindings[0], errors)).toBe(true);
+    });
 
     it("return false if model sign does not appear after first key", () => {
       const input = "{i18n >}"; // space is not allowed
@@ -149,6 +154,17 @@ describe("expression", () => {
 
     it("return true if the metadata separator is after adjacent first key", () => {
       const input = "{path/to/a/value}";
+      const { ast, errors } = parseBinding(input);
+      expect(isMetadataPath(ast.bindings[0], errors)).toBe(true);
+    });
+    it("return true if the metadata separator as HTML equivalent is before adjacent first key", () => {
+      const input = "{&#47;path/to/a/value}";
+      const { ast, errors } = parseBinding(input);
+      expect(isMetadataPath(ast.bindings[0], errors)).toBe(true);
+    });
+
+    it("return true if the metadata separator as HTML equivalent is after adjacent first key", () => {
+      const input = "{path&#x2F;to/a/value}";
       const { ast, errors } = parseBinding(input);
       expect(isMetadataPath(ast.bindings[0], errors)).toBe(true);
     });

--- a/packages/binding/src/services/completion/providers/property-binding-info.ts
+++ b/packages/binding/src/services/completion/providers/property-binding-info.ts
@@ -2,6 +2,8 @@ import {
   parseBinding,
   BindingParserTypes as BindingTypes,
   rangeContained,
+  isPropertyBindingInfo,
+  isBindingExpression,
 } from "@ui5-language-assistant/binding-parser";
 import type { Position } from "vscode-languageserver-types";
 import { AttributeValueCompletionOptions } from "@xml-tools/content-assist";
@@ -10,12 +12,7 @@ import { getUI5PropertyByXMLAttributeKey } from "@ui5-language-assistant/logic-u
 
 import { BindContext } from "../../../types";
 import { createInitialSnippet } from "./create-initial-snippet";
-import {
-  extractBindingExpression,
-  getCursorContext,
-  isBindingExpression,
-  isPropertyBindingInfo,
-} from "../../../utils";
+import { extractBindingExpression, getCursorContext } from "../../../utils";
 import { createAllSupportedElements } from "./create-all-supported-elements";
 import { createKeyProperties } from "./create-key-properties";
 import { createValue } from "./create-value";
@@ -80,7 +77,7 @@ export function propertyBindingInfoSuggestions({
       character: (value?.startColumn ?? 0) + startIndex,
       line: value?.startLine ? value.startLine - 1 : 0, // zero based index
     };
-    const { ast } = parseBinding(expression, position);
+    const { ast, errors } = parseBinding(expression, position);
     const input = expression;
     if (input.trim() === "") {
       completionItems.push(...createInitialSnippet());
@@ -96,7 +93,7 @@ export function propertyBindingInfoSuggestions({
     if (!binding) {
       continue;
     }
-    if (!isPropertyBindingInfo(text, binding)) {
+    if (!isPropertyBindingInfo(text, binding, errors)) {
       continue;
     }
     completionItems.push(...getCompletionItems(context, binding, ast.spaces));

--- a/packages/binding/src/services/diagnostics/validators/property-binding-info-validator.ts
+++ b/packages/binding/src/services/diagnostics/validators/property-binding-info-validator.ts
@@ -3,14 +3,13 @@ import { Context } from "@ui5-language-assistant/context";
 import { getUI5PropertyByXMLAttributeKey } from "@ui5-language-assistant/logic-utils";
 import { BindingIssue } from "../../../types";
 import { BINDING_ISSUE_TYPE } from "../../../constant";
-import {
-  extractBindingExpression,
-  getLogger,
-  isBindingExpression,
-  isPropertyBindingInfo,
-} from "../../../utils";
+import { extractBindingExpression, getLogger } from "../../../utils";
 import { Position } from "vscode-languageserver-types";
-import { parseBinding } from "@ui5-language-assistant/binding-parser";
+import {
+  parseBinding,
+  isPropertyBindingInfo,
+  isBindingExpression,
+} from "@ui5-language-assistant/binding-parser";
 import { checkAst } from "./issue-collector";
 import { filterLexerError, filterParseError } from "../../../utils/expression";
 
@@ -49,9 +48,10 @@ export function validatePropertyBindingInfo(
       };
       const { ast, errors } = parseBinding(expression, position);
       for (const binding of ast.bindings) {
-        if (!isPropertyBindingInfo(expression, binding)) {
+        if (!isPropertyBindingInfo(expression, binding, errors)) {
           continue;
         }
+
         issues.push(...checkAst(context, binding, errors));
 
         /**

--- a/packages/binding/src/utils/cursor.ts
+++ b/packages/binding/src/utils/cursor.ts
@@ -24,7 +24,7 @@ export const getCursorContext = (
   const el = elements.find((item) => positionContained(item.range, position));
   if (el) {
     // check key
-    if (positionContained(el.key?.range, position)) {
+    if (el.key && positionContained(el.key.range, position)) {
       return {
         type: "key",
         kind: "properties-excluding-duplicate",
@@ -32,7 +32,7 @@ export const getCursorContext = (
       };
     }
     // check colon => value
-    if (positionContained(el.colon?.range, position)) {
+    if (el.colon && positionContained(el.colon.range, position)) {
       return {
         type: "value",
         kind: "value",
@@ -40,7 +40,7 @@ export const getCursorContext = (
       };
     }
     // check value
-    if (positionContained(el.value?.range, position)) {
+    if (el.value && positionContained(el.value.range, position)) {
       return {
         type: "value",
         kind: "value",
@@ -56,7 +56,7 @@ export const getCursorContext = (
     // further check parts of adjacent element
     for (const el of elements) {
       // after adjacent key => value
-      if (isAfterAdjacentRange(spaceEl.range, el.key?.range)) {
+      if (el.key && isAfterAdjacentRange(spaceEl.range, el.key.range)) {
         // this happen when colon is missing
         return {
           type: "value",
@@ -65,7 +65,7 @@ export const getCursorContext = (
         };
       }
       // after adjacent colon => value
-      if (isAfterAdjacentRange(spaceEl.range, el.colon?.range)) {
+      if (el.colon && isAfterAdjacentRange(spaceEl.range, el.colon.range)) {
         return {
           type: "value",
           kind: "value",

--- a/packages/binding/src/utils/expression.ts
+++ b/packages/binding/src/utils/expression.ts
@@ -4,15 +4,6 @@ import {
 } from "@ui5-language-assistant/binding-parser";
 import { ExtractBindingExpression } from "..//types";
 
-/**
- * Syntax of a binding expression can be represented by `{=expression}` or `{:=expression}`
- * If an input text starts with either `{=` or `{:=`, input text is considered as binding expression
- */
-export const isBindingExpression = (input: string): boolean => {
-  input = input.trim();
-  return /^{(=|:=)/.test(input);
-};
-
 export const filterLexerError = (
   binding: BindingTypes.StructureValue,
   errors: {
@@ -43,47 +34,6 @@ export const filterParseError = (
   result.push(...parseErr);
 
   return result;
-};
-
-/**
- * An input is considered property binding syntax when
- *
- * a. is empty curly bracket e.g  `{}` or `{   }`
- *
- * b. has starting and closing curly bracket and key property with colon e.g `{anyKey: }` or `{"anyKey":}` or `{'anyKey':}`
- *
- * c. empty string [for initial code completion snippet]
- */
-export const isPropertyBindingInfo = (
-  input: string,
-  binding?: BindingTypes.StructureValue
-): boolean => {
-  // check empty string
-  if (input.trim().length === 0) {
-    return true;
-  }
-
-  if (!binding) {
-    return false;
-  }
-
-  // check empty curly brackets
-  if (
-    binding.leftCurly &&
-    binding.leftCurly.text &&
-    binding.elements.length === 0
-  ) {
-    return true;
-  }
-  // check it has at least one key with colon
-  const result = binding.elements.find(
-    /* istanbul ignore next */
-    (item) => item.key?.text && item.colon?.text
-  );
-  if (result && binding.leftCurly && binding.leftCurly.text) {
-    return true;
-  }
-  return false;
 };
 
 /**

--- a/packages/binding/src/utils/index.ts
+++ b/packages/binding/src/utils/index.ts
@@ -1,8 +1,4 @@
-export {
-  isBindingExpression,
-  extractBindingExpression,
-  isPropertyBindingInfo,
-} from "./expression";
+export { extractBindingExpression } from "./expression";
 
 export {
   typesToValue,

--- a/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
+++ b/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
@@ -75,6 +75,12 @@ describe("property-binding-info-validator", () => {
     const result = await validateView(snippet);
     expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([]);
   });
+  it("do not check metadata binding with contains colon", async () => {
+    const snippet = `
+     <Label text="{/SomeValue/#@sap:label}" id="some_label" />`;
+    const result = await validateView(snippet);
+    expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([]);
+  });
   it("do not check simple binding", async () => {
     const snippet = `
    <Input value="{/firstName}"/>`;
@@ -93,6 +99,12 @@ describe("property-binding-info-validator", () => {
     const result = await validateView(snippet);
     expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([]);
   });
+  it("do not check model which contains colon", async () => {
+    const snippet = `
+    <Label text="{oData>/SomeValue/#@sap:label}" id="some_label" />`;
+    const result = await validateView(snippet);
+    expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([]);
+  });
   it("check unknown char", async () => {
     const snippet = `
     <Text text="{ # path: '' }" id="test-id"></Text>`;
@@ -101,6 +113,23 @@ describe("property-binding-info-validator", () => {
       "kind: UnknownChar; text: Unknown character; severity:error; range:9:18-9:19",
     ]);
   });
+  it("check unknown char [> or >/]", async () => {
+    const snippet = `
+    <Text text="{ path: '' > }" id="test-id"></Text>`;
+    const result = await validateView(snippet);
+    expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
+      "kind: UnknownChar; text: Unknown character; severity:error; range:9:27-9:28",
+    ]);
+  });
+  it("check unknown char [/]", async () => {
+    const snippet = `
+    <Text text="{ path: '' / }" id="test-id"></Text>`;
+    const result = await validateView(snippet);
+    expect(result.map((item) => issueToSnapshot(item))).toStrictEqual([
+      "kind: UnknownChar; text: Unknown character; severity:error; range:9:27-9:28",
+    ]);
+  });
+
   it("check wrong property binding", async () => {
     const snippet = `
     <Text text="{path: ' ', party }" id="test-id"></Text>`;

--- a/packages/binding/test/unit/utils/expression.test.ts
+++ b/packages/binding/test/unit/utils/expression.test.ts
@@ -1,25 +1,6 @@
-import {
-  extractBindingExpression,
-  isBindingExpression,
-  isPropertyBindingInfo,
-} from "../../../src/utils";
-import { parseBinding } from "@ui5-language-assistant/binding-parser";
+import { extractBindingExpression } from "../../../src/utils";
 
 describe("expression", () => {
-  describe("isBindingExpression", () => {
-    it("check binding expression {=", () => {
-      const result = isBindingExpression("{=");
-      expect(result).toBeTrue();
-    });
-    it("check  binding expression {:=", () => {
-      const result = isBindingExpression("{:=");
-      expect(result).toBeTrue();
-    });
-    it("check other false cases", () => {
-      const result = isBindingExpression("{");
-      expect(result).toBeFalse();
-    });
-  });
   describe("extractBindingExpression", () => {
     it("empty text", () => {
       const input = " ";
@@ -205,56 +186,6 @@ describe("expression", () => {
           startIndex: 4,
         },
       ]);
-    });
-  });
-  describe("isPropertyBindingInfo", () => {
-    it("empty string", () => {
-      const input = "  ";
-      const { ast } = parseBinding(input);
-      const result = isPropertyBindingInfo(input, ast.bindings[0]);
-      expect(result).toBeTrue();
-    });
-    it("string value", () => {
-      const input = "40";
-      const { ast } = parseBinding(input);
-      const result = isPropertyBindingInfo(input, ast.bindings[0]);
-      expect(result).toBeFalse();
-    });
-    it("empty curly bracket without space", () => {
-      const input = "{}";
-      const { ast } = parseBinding(input);
-      const result = isPropertyBindingInfo(input, ast.bindings[0]);
-      expect(result).toBeTrue();
-    });
-    it("empty curly bracket with space", () => {
-      const input = "{   }";
-      const { ast } = parseBinding(input);
-      const result = isPropertyBindingInfo(input, ast.bindings[0]);
-      expect(result).toBeTrue();
-    });
-    it("key with colone [true]", () => {
-      const input = ' {path: "some/path"}';
-      const { ast } = parseBinding(input);
-      const result = isPropertyBindingInfo(input, ast.bindings[0]);
-      expect(result).toBeTrue();
-    });
-    it("key with colone any where [true]", () => {
-      const input = ' {path "some/path", thisKey: {}}';
-      const { ast } = parseBinding(input);
-      const result = isPropertyBindingInfo(input, ast.bindings[0]);
-      expect(result).toBeTrue();
-    });
-    it("missing colon [false]", () => {
-      const input = '{path "some/path"}';
-      const { ast } = parseBinding(input);
-      const result = isPropertyBindingInfo(input, ast.bindings[0]);
-      expect(result).toBeFalse();
-    });
-    it("contains > [false]", () => {
-      const input = "{i18n>myTestModel}";
-      const { ast } = parseBinding(input);
-      const result = isPropertyBindingInfo(input, ast.bindings[0]);
-      expect(result).toBeFalse();
     });
   });
 });


### PR DESCRIPTION
fix unjustified error for following points.

* escape diagnostic for metadata binding that contains colon e.g `{/SomeValue/#@sap:label}`
    * consider also HTML equivalent e.g. `&#47;` or `&#x2F;`
* escape diagnostic for model that contains colon e.g https://github.com/SAP/ui5-language-assistant/issues/637
    *   consider also HTML equivalent `&gt;`

Refactoring
* move some logic to `binding-parser` package for reuse