### PR TITLE
fix: validate prop binding with exp binding

### DIFF
--- a/.changeset/lemon-vans-run.md
+++ b/.changeset/lemon-vans-run.md
@@ -1,0 +1,8 @@
+---
+"@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext": patch
+"vscode-ui5-language-assistant": patch
+"@ui5-language-assistant/binding-parser": patch
+"@ui5-language-assistant/binding": patch
+---
+
+fix: validate binding after expression binding

--- a/packages/binding-parser/src/constant.ts
+++ b/packages/binding-parser/src/constant.ts
@@ -23,3 +23,6 @@ export const VALUE = "value";
 
 export const LEXER_ERROR = "lexer-error";
 export const PARSE_ERROR = "parse-error";
+
+export const END_OF_LINE = /\r|\n|\r\n/;
+export const WHITE_SPACE_REG = /[ \t\f]+/;

--- a/packages/binding-parser/src/types/index.ts
+++ b/packages/binding-parser/src/types/index.ts
@@ -1,7 +1,14 @@
+import { LEFT_CURLY, RIGHT_CURLY } from "../constant";
 export * as BindingParserTypes from "./binding-parser";
 
 export interface ExtractBindingSyntax {
   startIndex: number;
   endIndex: number;
   expression: string;
+}
+
+export interface Token {
+  type: typeof LEFT_CURLY | typeof RIGHT_CURLY;
+  start: number;
+  end: number;
 }

--- a/packages/binding-parser/test/unit/utils/expression.test.ts
+++ b/packages/binding-parser/test/unit/utils/expression.test.ts
@@ -143,10 +143,15 @@ describe("expression", () => {
       const result = extractBindingSyntax(input);
       expect(result).toStrictEqual([
         {
-          endIndex: 109,
+          endIndex: 65,
           expression:
-            "{\n        events: {\n          key01: \"abc\",\n        }\n\t\t\t}\n      {\n        path: 'some/value',\n      }",
+            '{\n        events: {\n          key01: "abc",\n        }\n\t\t\t}',
           startIndex: 7,
+        },
+        {
+          endIndex: 109,
+          expression: "{\n        path: 'some/value',\n      }",
+          startIndex: 72,
         },
       ]);
     });
@@ -165,10 +170,15 @@ describe("expression", () => {
       const result = extractBindingSyntax(input);
       expect(result).toStrictEqual([
         {
-          endIndex: 116,
+          endIndex: 64,
           expression:
-            "{\n        events: \n          key01: \"abc\",\n        }\n\t\t\t}\n      {\n        path: '',\n        events: {\n      }",
+            '{\n        events: \n          key01: "abc",\n        }\n\t\t\t}',
           startIndex: 7,
+        },
+        {
+          endIndex: 116,
+          expression: "{\n        path: '',\n        events: {\n      }",
+          startIndex: 71,
         },
       ]);
     });
@@ -177,9 +187,14 @@ describe("expression", () => {
       const result = extractBindingSyntax(input);
       expect(result).toStrictEqual([
         {
-          endIndex: 26,
-          expression: "{path:'' } , {events: { }}",
+          endIndex: 10,
+          expression: "{path:'' }",
           startIndex: 0,
+        },
+        {
+          endIndex: 26,
+          expression: "{events: { }}",
+          startIndex: 13,
         },
       ]);
     });
@@ -188,9 +203,32 @@ describe("expression", () => {
       const result = extractBindingSyntax(input);
       expect(result).toStrictEqual([
         {
-          endIndex: 35,
-          expression: "{parts: [' ']} $$ {path: '###'}",
+          endIndex: 18,
+          expression: "{parts: [' ']}",
           startIndex: 4,
+        },
+        {
+          endIndex: 35,
+          expression: "{path: '###'}",
+          startIndex: 22,
+        },
+      ]);
+    });
+    it("expression binding and property binding info", () => {
+      const input =
+        "{= ${/actionButtonsInfo/midColumn/closeColumn} !== null } {parts: [' ']}";
+      const result = extractBindingSyntax(input);
+      expect(result).toStrictEqual([
+        {
+          endIndex: 57,
+          expression:
+            "{= ${/actionButtonsInfo/midColumn/closeColumn} !== null }",
+          startIndex: 0,
+        },
+        {
+          endIndex: 72,
+          expression: "{parts: [' ']}",
+          startIndex: 58,
         },
       ]);
     });

--- a/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
+++ b/packages/binding/test/unit/services/diagnostics/validators/property-binding-info-validator.test.ts
@@ -706,6 +706,18 @@ describe("property-binding-info-validator", () => {
         ]
       `);
     });
+    it("do not ignore validation after expression binding", async () => {
+      const snippet = `
+     <Input value="{= \${/actionButtonsInfo/midColumn/closeColumn} !== null } {parts: [' '], path: ''}"/>`;
+      const result = await validateView(snippet);
+      expect(result.map((item) => issueToSnapshot(item)))
+        .toMatchInlineSnapshot(`
+        Array [
+          "kind: NotAllowedProperty; text: One of these elements [parts, path] are allowed; severity:info; range:9:78-9:83",
+          "kind: NotAllowedProperty; text: One of these elements [parts, path] are allowed; severity:info; range:9:92-9:96",
+        ]
+      `);
+    });
   });
   describe("quotes", () => {
     it("no wrong diagnostic for quotes", async () => {


### PR DESCRIPTION
**Issue:** 
Currently if `expression binding` is used along with `property binding info`, `property binding info` was ignored (no LSP support). 
Code example
```XML
<Button id="test" text="{= ${/actionButtonsInfo/midColumn/closeColumn} !== null } {parts: [' '] }"></Text>
```
This PR solves that issue.