### PR TITLE
fix: support `minUI5Version` as an array

### DIFF
--- a/.changeset/few-rules-raise.md
+++ b/.changeset/few-rules-raise.md
@@ -1,0 +1,5 @@
+---
+"@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext": patch
+---
+
+fix: support `minUI5Version` as an array

--- a/packages/vscode-ui5-language-assistant-bas-ext/package.json
+++ b/packages/vscode-ui5-language-assistant-bas-ext/package.json
@@ -2,7 +2,7 @@
   "name": "@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext",
   "description": "A wrapper module for BAS simple extension around Language Support For SAPUI5",
   "license": "Apache-2.0",
-  "version": "4.0.65",
+  "version": "4.0.64",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/vscode-ui5-language-assistant-bas-ext/package.json
+++ b/packages/vscode-ui5-language-assistant-bas-ext/package.json
@@ -2,7 +2,7 @@
   "name": "@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext",
   "description": "A wrapper module for BAS simple extension around Language Support For SAPUI5",
   "license": "Apache-2.0",
-  "version": "4.0.64",
+  "version": "4.0.65",
   "private": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
To be able to publish to [npm.js ](https://www.npmjs.com/package/@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext?activeTab=versions) version of `"@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext"` must be sync with `"vscode-ui5-language-assistant"`. In last PR, it was forgotten to include it in change set.
