### PR TITLE
feat: add standalone sonar workflow

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,56 @@
+name: Sonar
+
+on:
+  workflow_run:
+    workflows: ['Release workflow']
+    types:
+      - completed
+
+jobs:
+  sonar:
+    name: Sonar analysis
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment: production
+    permissions:
+      actions: read # Required to download artifacts
+      pull-requests: write # Required for PR decoration comments
+      statuses: write # Required for SonarCloud to post quality gate commit status
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: Download cached artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sonar-artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.ACCESS_PAT }}
+          merge-multiple: true
+
+      - name: Extract output artifact
+        shell: bash
+        run: tar -xf output.tar
+
+      - name: Read pull request event
+        shell: bash
+        run: |
+          echo "pr_number=$(sed '1q;d' pr-event.txt)" >> "$GITHUB_ENV"
+          echo "pr_head_ref=$(sed '2q;d' pr-event.txt)" >> "$GITHUB_ENV"
+          echo "pr_base_ref=$(sed '3q;d' pr-event.txt)" >> "$GITHUB_ENV"
+
+      - name: Run SonarCloud scan
+        uses: SonarSource/sonarqube-scan-action@2500896589ef8f7247069a56136f8dc177c27ccf # v5.2.0
+        with:
+          args: >
+            ${{ github.event.workflow_run.event == 'pull_request' && format('{0}{1}', '-Dsonar.scm.revision=', github.event.workflow_run.head_sha) || '' }}
+            ${{ github.event.workflow_run.event == 'pull_request' && format('{0}{1}', '-Dsonar.pullrequest.key=', env.pr_number) || '' }}
+            ${{ github.event.workflow_run.event == 'pull_request' && format('{0}{1}', '-Dsonar.pullrequest.branch=', env.pr_head_ref) || '' }}
+            ${{ github.event.workflow_run.event == 'pull_request' && format('{0}{1}', '-Dsonar.pullrequest.base=', env.pr_base_ref) || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/packages/binding/test/unit/definition/__snapshots__/definition.test.ts.snap
+++ b/packages/binding/test/unit/definition/__snapshots__/definition.test.ts.snap
@@ -997,7 +997,7 @@ Array [
 
 **Optional:** false
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "path",
     "required": true,
@@ -1028,7 +1028,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "model",
     "type": Array [
@@ -1058,7 +1058,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "template",
     "type": Array [
@@ -2714,7 +2714,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "templateShareable",
     "type": Array [
@@ -2744,7 +2744,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "factory",
     "type": Array [
@@ -2774,7 +2774,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "suspended",
     "type": Array [
@@ -2804,7 +2804,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "startIndex",
     "type": Array [
@@ -2834,7 +2834,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "length",
     "type": Array [
@@ -2864,7 +2864,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "sorter",
     "type": Array [
@@ -2887,7 +2887,7 @@ Array [
 
 **Optional:** false
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Sorter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Sorter)",
             },
             "name": "path",
             "required": true,
@@ -2918,7 +2918,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Sorter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Sorter)",
             },
             "name": "descending",
             "required": false,
@@ -2949,7 +2949,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Sorter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Sorter)",
             },
             "name": "group",
             "required": false,
@@ -2991,7 +2991,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Sorter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Sorter)",
             },
             "name": "comparator",
             "required": false,
@@ -3035,7 +3035,7 @@ Array [
 
 **Optional:** false
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Sorter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Sorter)",
             },
             "name": "path",
             "required": true,
@@ -3066,7 +3066,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Sorter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Sorter)",
             },
             "name": "descending",
             "required": false,
@@ -3097,7 +3097,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Sorter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Sorter)",
             },
             "name": "group",
             "required": false,
@@ -3139,7 +3139,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Sorter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Sorter)",
             },
             "name": "comparator",
             "required": false,
@@ -3179,7 +3179,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "filters",
     "type": Array [
@@ -3202,7 +3202,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "path",
             "required": false,
@@ -3233,7 +3233,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "test",
             "required": false,
@@ -3264,7 +3264,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "comparator",
             "required": false,
@@ -3295,7 +3295,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "operator",
             "required": false,
@@ -3343,7 +3343,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "value1",
             "required": false,
@@ -3370,7 +3370,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "value2",
             "required": false,
@@ -3397,7 +3397,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "variable",
             "required": false,
@@ -3428,7 +3428,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "condition",
             "required": false,
@@ -3460,7 +3460,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "filters",
             "required": false,
@@ -3492,7 +3492,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "and",
             "required": false,
@@ -3523,7 +3523,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "caseSensitive",
             "required": false,
@@ -3567,7 +3567,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "path",
             "required": false,
@@ -3598,7 +3598,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "test",
             "required": false,
@@ -3629,7 +3629,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "comparator",
             "required": false,
@@ -3660,7 +3660,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "operator",
             "required": false,
@@ -3708,7 +3708,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "value1",
             "required": false,
@@ -3735,7 +3735,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "value2",
             "required": false,
@@ -3762,7 +3762,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "variable",
             "required": false,
@@ -3793,7 +3793,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "condition",
             "required": false,
@@ -3825,7 +3825,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "filters",
             "required": false,
@@ -3857,7 +3857,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "and",
             "required": false,
@@ -3888,7 +3888,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
             },
             "name": "caseSensitive",
             "required": false,
@@ -3928,7 +3928,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "key",
     "type": Array [
@@ -3969,7 +3969,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "parameters",
     "type": Array [
@@ -3999,7 +3999,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "groupHeaderFactory",
     "type": Array [
@@ -4029,7 +4029,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.AggregationBindingInfo)",
     },
     "name": "events",
     "type": Array [
@@ -4064,7 +4064,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "path",
     "type": Array [
@@ -4097,7 +4097,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "value",
     "type": Array [
@@ -4130,7 +4130,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "model",
     "type": Array [
@@ -4160,7 +4160,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "suspended",
     "type": Array [
@@ -4193,7 +4193,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "formatter",
     "type": Array [
@@ -4225,7 +4225,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "useRawValues",
     "type": Array [
@@ -4260,7 +4260,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "useInternalValues",
     "type": Array [
@@ -4293,7 +4293,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "type",
     "type": Array [
@@ -4373,7 +4373,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "targetType",
     "type": Array [
@@ -4403,7 +4403,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "formatOptions",
     "type": Array [
@@ -4444,7 +4444,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "constraints",
     "type": Array [
@@ -4485,7 +4485,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "mode",
     "type": Array [
@@ -4520,7 +4520,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "parameters",
     "type": Array [
@@ -4550,7 +4550,7 @@ Array [
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "events",
     "type": Array [
@@ -4584,7 +4584,7 @@ If a part is not specified as a binding info object but as a simple string, a bi
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
     },
     "name": "parts",
     "type": Array [

--- a/packages/binding/test/unit/services/hover/__snapshots__/hover.test.ts.snap
+++ b/packages/binding/test/unit/services/hover/__snapshots__/hover.test.ts.snap
@@ -14,7 +14,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
   },
 }
 `;
@@ -33,7 +33,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
   },
 }
 `;
@@ -52,7 +52,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
   },
 }
 `;
@@ -71,7 +71,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
   },
 }
 `;
@@ -90,7 +90,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
   },
 }
 `;
@@ -109,7 +109,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.model.Filter)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.model.Filter)",
   },
 }
 `;
@@ -132,7 +132,7 @@ If a part is not specified as a binding info object but as a simple string, a bi
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
   },
 }
 `;
@@ -151,7 +151,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
   },
 }
 `;
@@ -170,7 +170,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
   },
 }
 `;
@@ -189,7 +189,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
   },
 }
 `;
@@ -208,7 +208,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
   },
 }
 `;
@@ -227,7 +227,7 @@ Object {
 
 **Optional:** true
 
-[More information](https://ui5.sap.com/1.108.52/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
+[More information](https://ui5.sap.com/1.108.53/#/api/sap.ui.base.ManagedObject.PropertyBindingInfo)",
   },
 }
 `;


### PR DESCRIPTION
## Summary
- Adds a standalone `sonar.yaml` workflow triggered via `workflow_run` on `Release workflow` completion
- Runs SonarCloud analysis on both PRs and pushes to master
- Aligned with the `open-ux-tools` repo pattern

## Why separate PR?
`sonar.yaml` needs to exist on `master` before PR [#799](https://github.com/SAP/ui5-language-assistant/pull/799) can be merged, since `workflow_run` only reads workflow files from the default branch.

## Test plan
- [ ] Merge this PR first
- [ ] Verify SonarCloud reports on PR #799 after re-triggering it
- [ ] Merge PR #799