### PR TITLE
fix: use dedicated sonar environment without required-reviewer gate

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Sonar analysis
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    environment: production
+    environment: sonar
     permissions:
       actions: read # Required to download artifacts
       pull-requests: write # Required for PR decoration comments


### PR DESCRIPTION
## Summary
- Changes `environment: production` → `environment: sonar` in `sonar.yaml`

## Why
The `production` environment has required reviewers, which causes the Sonar job to sit in `waiting` state and never report a status back to PRs.

The `workflow_run` trigger already provides the same secret isolation that `environment: production` was added to enforce — the job always runs in the base repo's context on `master`, never in a fork/PR branch's context. So `SONAR_TOKEN` and `ACCESS_PAT` are never exposed to untrusted code regardless.
