### PR TITLE
fix: server issue and audit issue

### DIFF
--- a/.changeset/wet-paws-sort.md
+++ b/.changeset/wet-paws-sort.md
@@ -1,0 +1,6 @@
+---
+"@ui5-language-assistant/vscode-ui5-language-assistant-bas-ext": patch
+"vscode-ui5-language-assistant": patch
+---
+
+fix: server crash

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format:fix": "prettier --write \"**/*.@(js|ts|json|md)\" --ignore-path=.gitignore",
     "format:validate": "prettier --check \"**/*.@(js|ts|json|md)\" --ignore-path=.gitignore",
     "lint": "eslint . --ext .ts --fix --max-warnings=0 --ignore-path=.gitignore",
-    "ci:subpackages": "pnpm -r --filter=!@ui5-language-assistant/language-server run ci",
+    "ci:subpackages": "pnpm -r run ci",
     "test": "pnpm -r run test",
     "coverage": "pnpm -r run coverage",
     "clean": "pnpm -r run clean",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   '@tootallnate/once': ^3.0.1
   tough-cookie: ^5.0.0
   uuid: '>=9.0.0'
+  shell-quote: '>=1.8.4'
 
 importers:
 
@@ -4878,8 +4879,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
@@ -9864,7 +9865,7 @@ snapshots:
       minimatch: 3.1.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       string.prototype.padend: 3.1.6
 
   npm-run-path@4.0.1:
@@ -10393,7 +10394,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shelljs@0.8.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,4 @@ overrides:
   '@tootallnate/once': '^3.0.1'
   tough-cookie: '^5.0.0'
   uuid: '>=9.0.0'
+  shell-quote: '>=1.8.4'


### PR DESCRIPTION
## Problem

The released VSIX ([v4.0.96](https://github.com/SAP/ui5-language-assistant/releases/tag/v4.0.96)) was missing
`extension/node_modules/@ui5-language-assistant/language-server/dist/server.js`,
causing the language server to fail to start after installation.

**Root cause:** The root `ci:subpackages` script explicitly excluded
`@ui5-language-assistant/language-server` from the recursive `ci` run:

```json
"ci:subpackages": "pnpm -r --filter=!@ui5-language-assistant/language-server run ci"
```
This meant the language-server's bundle step — which produces dist/server.js via esbuild — never ran in CI.
The bug was invisible locally because pnpm resolves node_modules/@ui5-language-assistant/language-server as a symlink to the real workspace package, which retains dist/server.js from previous local builds. CI always starts from a clean checkout, so the file was never present.