### PR TITLE
Update deploy_maual.yaml

### DIFF
--- a/.github/workflows/deploy_maual.yaml
+++ b/.github/workflows/deploy_maual.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [20.x]
+        node-version: [22.x]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 9.15.4
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
fix: resolve pnpm version conflict and align node version in deploy workflow

Remove explicit version: 9.15.4 from pnpm/action-setup step — pnpm version is already declared via packageManager: pnpm@11.1.0 in package.json, causing a conflict at runtime
Update node-version from 20.x to 22.x to align with release.yaml